### PR TITLE
chore: [CHATS-670] add mime type and file size to the XMPP message

### DIFF
--- a/carbonio-chats-ce-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/MessageDispatcher.java
+++ b/carbonio-chats-ce-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/MessageDispatcher.java
@@ -95,10 +95,13 @@ public interface MessageDispatcher extends HealthIndicator {
    * @param senderId     operation user identifier
    * @param attachmentId identifier of the attachment to send
    * @param fileName     name of the attachment
+   * @param mimeType     file mime type
+   * @param fileSize     file size
    * @param description  description of the attachment
    * @param messageId    identifier of XMPP message to create
    */
   void sendAttachment(
-    String roomId, String senderId, String attachmentId, String fileName, String description, @Nullable String messageId
+    String roomId, String senderId, String attachmentId, String fileName, String mimeType, long fileSize,
+    String description, @Nullable String messageId
   );
 }

--- a/carbonio-chats-ce-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/MessageDispatcherMongooseIm.java
+++ b/carbonio-chats-ce-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/MessageDispatcherMongooseIm.java
@@ -208,10 +208,15 @@ public class MessageDispatcherMongooseIm implements MessageDispatcher {
 
   @Override
   public void sendAttachment(
-    String roomId, String senderId, String attachmentId, String fileName, String description, @Nullable String messageId
+    String roomId, String senderId, String attachmentId, String fileName, String mimeType, long fileSize, String description, @Nullable String messageId
   ) {
     GraphQlResponse result = sendStanza(roomId, senderId, MessageType.ATTACHMENT_ADDED,
-      Map.of("attachment-id", attachmentId, "filename", fileName), description, messageId);
+      Map.of(
+        "attachment-id", attachmentId,
+        "filename", fileName,
+        "mime-type", mimeType,
+        "size", String.valueOf(fileSize)
+      ), description, messageId);
     if (result.errors != null) {
       try {
         throw new MessageDispatcherException(

--- a/carbonio-chats-ce-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/AttachmentServiceImpl.java
+++ b/carbonio-chats-ce-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/AttachmentServiceImpl.java
@@ -154,7 +154,8 @@ public class AttachmentServiceImpl implements AttachmentService {
       .roomId(roomId.toString());
     metadata = fileMetadataRepository.save(metadata);
     storagesService.saveFile(file, metadata, currentUser.getId());
-    messageDispatcher.sendAttachment(roomId.toString(), currentUser.getId(), id.toString(), fileName, description, messageId);
+    messageDispatcher.sendAttachment(roomId.toString(), currentUser.getId(), id.toString(), fileName, mimeType, file.length(), description,
+      messageId);
     eventDispatcher.sendToUserQueue(
       room.getSubscriptions().stream().map(Subscription::getUserId).collect(Collectors.toList()),
       AttachmentAddedEvent.create(currentUser.getUUID(), currentUser.getSessionId())

--- a/carbonio-chats-ce-it/src/test/java/com/zextras/carbonio/chats/it/RoomsApiIT.java
+++ b/carbonio-chats-ce-it/src/test/java/com/zextras/carbonio/chats/it/RoomsApiIT.java
@@ -3198,7 +3198,11 @@ public class RoomsApiIT {
       FileMock fileMock = MockedFiles.get(MockedFileType.PEANUTS_IMAGE);
 
       mongooseImMockServer.mockSendStanza(roomId.toString(), user1Id.toString(), "attachmentAdded",
-        Map.of("attachment-id", fileMock.getId(), "filename", fileMock.getName()), "", null, true);
+        Map.of(
+          "attachment-id", fileMock.getId(),
+          "filename", fileMock.getName(),
+          "mime-type", fileMock.getMimeType(),
+          "size", String.valueOf(fileMock.getSize())), "", null, true);
       MockHttpResponse response;
       try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
         uuid.when(UUID::randomUUID).thenReturn(fileMock.getUUID());
@@ -3217,7 +3221,11 @@ public class RoomsApiIT {
       assertEquals(201, response.getStatus());
       mongooseImMockServer.verify(
         mongooseImMockServer.getSendStanzaRequest(roomId.toString(), user1Id.toString(), "attachmentAdded",
-          Map.of("attachment-id", fileMock.getId(), "filename", fileMock.getName()), "", null),
+          Map.of(
+            "attachment-id", fileMock.getId(),
+            "filename", fileMock.getName(),
+            "mime-type", fileMock.getMimeType(),
+            "size", String.valueOf(fileMock.getSize())), "", null),
         VerificationTimes.exactly(1));
       userManagementMockServer.verify("GET", String.format("/auth/token/%s", user1Token), 1);
       storageMockServer.verify("PUT", "/upload", fileMock.getId(), 1);
@@ -3239,7 +3247,11 @@ public class RoomsApiIT {
       String description = "peanuts image";
 
       mongooseImMockServer.mockSendStanza(roomId.toString(), user1Id.toString(), "attachmentAdded",
-        Map.of("attachment-id", fileMock.getId(), "filename", fileMock.getName()), description, "the-xmpp-message-id",
+        Map.of(
+          "attachment-id", fileMock.getId(),
+          "filename", fileMock.getName(),
+          "mime-type", fileMock.getMimeType(),
+          "size", String.valueOf(fileMock.getSize())), description, "the-xmpp-message-id",
         true);
       MockHttpResponse response;
       try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
@@ -3260,7 +3272,11 @@ public class RoomsApiIT {
       assertEquals(201, response.getStatus());
       mongooseImMockServer.verify(
         mongooseImMockServer.getSendStanzaRequest(roomId.toString(), user1Id.toString(), "attachmentAdded",
-          Map.of("attachment-id", fileMock.getId(), "filename", fileMock.getName()), description,
+          Map.of(
+            "attachment-id", fileMock.getId(),
+            "filename", fileMock.getName(),
+            "mime-type", fileMock.getMimeType(),
+            "size", String.valueOf(fileMock.getSize())), description,
           "the-xmpp-message-id"),
         VerificationTimes.exactly(1));
       userManagementMockServer.verify("GET", String.format("/auth/token/%s", user1Token), 1);


### PR DESCRIPTION
Add the mime type and file size properties to the XMPP message that an attachment has been uploaded