### PR TITLE
fix: move jar from /usr/bin to /usr/share to follow the FHS standard

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -19,43 +19,46 @@ backup=(
   "etc/zextras/service-discover/carbonio-ws-collaboration.hcl"
 )
 source=(
+  "carbonio-ws-collaboration"
   "carbonio-ws-collaboration-configs"
-  "carbonio-ws-collaboration-setup.sh"
-  "carbonio-ws-collaboration-sidecar.service"
+  "carbonio-ws-collaboration-setup"
+  "carbonio-ws-collaboration-pending-setup"
   "carbonio-ws-collaboration.hcl"
   "carbonio-ws-collaboration.service"
-  "carbonio-ws-collaboration"
-  "intentions.json"
+  "carbonio-ws-collaboration-sidecar.service"
   "logback.xml"
+  "intentions.json"
   "policies.json"
   "service-protocol.json"
 )
-sha256sums=('0ab411e66f63b6384c5aaf8537e5a8ef3135db162fa2a052266d6a847f5e9812'
-  '97256a878d94c5239c422049c9360ca18e1c34c74b3e6ac2a93e51ae0419b423'
-  '1320c458d4daa43b2b11cd694d472b635c2de547a67531605cbc2ac2afbd8b9a'
+sha256sums=('0491cce45da900c13141416b2ba9f04de3df067fca2f136f0f03892f1b2c1d1a'
+  '0ab411e66f63b6384c5aaf8537e5a8ef3135db162fa2a052266d6a847f5e9812'
+  '3b7439a5c9e2c84af0508ac9b4e20ca904dbf276a129c4c3c65f1fcb31ac9757'
+  'e9f6604fd073a5cf3cf9b448d6f9f372a64e23f84fc26d7a0fac6d55b11f0c6a'
   'e077e36d3824463d6618b7075a540037773457cc6b8ff1f105ea5e64dd3e750a'
-  'e081604be153b45a556ebb5515124a11c2d0870a978a583344f8f7be37e307ae'
-  'ce7262f2c01e4f6c700265f88892d7572dc546d2ff328506dfd7f5502c6b6b0b'
-  '58c69efd45348762b3c603ecb8a7d3df5e4ada730b00a760d02d3f376a455d08'
+  '37b6593426aa0e5a209def34a25fee30907e40278b9f35cc6e21b62303b7c39a'
+  '1320c458d4daa43b2b11cd694d472b635c2de547a67531605cbc2ac2afbd8b9a'
   'a993f63dbfa8273d92f004c6db2886f17d9876d36c65ab757456ab99c0a3f3c3'
+  '58c69efd45348762b3c603ecb8a7d3df5e4ada730b00a760d02d3f376a455d08'
   '7dbc2225d51fb07c1e3e5577f8ba80d8cd9634c7c47f5b0ab1edbc949d97ff21'
   'd3741e4103a786c40a319248258ee5a25a39174a6ba80973b5877bb8a5e2bf72')
 
 package() {
   cd "${srcdir}"/../../ws-collaboration
-  install -Dm 644 ./carbonio-ws-collaboration-boot/target/carbonio-ws-collaboration-ce-fatjar.jar \
-    "${pkgdir}/usr/bin/carbonio/ws-collaboration/carbonio-ws-collaboration.jar"
+  install -Dm 755 ./carbonio-ws-collaboration-boot/target/carbonio-ws-collaboration-ce-fatjar.jar \
+    "${pkgdir}/usr/share/carbonio/carbonio-ws-collaboration.jar"
 
   cd "${srcdir}"
   install -Dm 755 carbonio-ws-collaboration "${pkgdir}/usr/bin/carbonio-ws-collaboration"
   install -Dm 755 carbonio-ws-collaboration-configs "${pkgdir}/usr/bin/carbonio-ws-collaboration-configs"
-  install -Dm 644 logback.xml "${pkgdir}/etc/carbonio/ws-collaboration/logback.xml"
+  install -Dm 755 carbonio-ws-collaboration-setup "${pkgdir}/usr/bin/carbonio-ws-collaboration-setup"
+  install -Dm 644 carbonio-ws-collaboration-pending-setup "${pkgdir}/etc/zextras/pending-setups.d/carbonio-ws-collaboration.sh"
+  install -Dm 644 carbonio-ws-collaboration.hcl "${pkgdir}/etc/zextras/service-discover/carbonio-ws-collaboration.hcl"
   install -Dm 644 carbonio-ws-collaboration.service "${pkgdir}/lib/systemd/system/carbonio-ws-collaboration.service"
   install -Dm 644 carbonio-ws-collaboration-sidecar.service "${pkgdir}/lib/systemd/system/carbonio-ws-collaboration-sidecar.service"
-  install -Dm 644 carbonio-ws-collaboration.hcl "${pkgdir}/etc/zextras/service-discover/carbonio-ws-collaboration.hcl"
-  install -Dm 644 carbonio-ws-collaboration-setup.sh "${pkgdir}/etc/zextras/pending-setups.d/carbonio-ws-collaboration.sh"
-  install -Dm 644 policies.json "${pkgdir}/etc/carbonio/ws-collaboration/service-discover/policies.json"
+  install -Dm 644 logback.xml "${pkgdir}/etc/carbonio/ws-collaboration/logback.xml"
   install -Dm 644 intentions.json "${pkgdir}/etc/carbonio/ws-collaboration/service-discover/intentions.json"
+  install -Dm 644 policies.json "${pkgdir}/etc/carbonio/ws-collaboration/service-discover/policies.json"
   install -Dm 644 service-protocol.json "${pkgdir}/etc/carbonio/ws-collaboration/service-discover/service-protocol.json"
 }
 

--- a/package/carbonio-ws-collaboration
+++ b/package/carbonio-ws-collaboration
@@ -1,83 +1,14 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# decrypt the bootstrap token, asking the password to the sys admin
-# --setup check for SETUP_CONSUL_TOKEN env. variable and uses it
-# to avoid re-asking for the password
-if [[ $(id -u) -ne 0 ]]; then
-  echo "Please run as root"
-  exit 1
-fi
-
-if [[ "$1" != "setup" ]]; then
-  echo "Syntax: 'carbonio-ws-collaboration setup' to automatically configure the service"
-  exit 1;
-fi
-
-# Decrypt the bootstrap token, asking the password to the sys admin
-# --setup check for SETUP_CONSUL_TOKEN env. variable and uses it
-# to avoid re-asking for the password
-echo -n "Insert the cluster credential password: "
-export CONSUL_HTTP_TOKEN=$(service-discover bootstrap-token --setup)
-EXIT_CODE="$?"
-echo ""
-if [[ "${EXIT_CODE}" != "0" ]]; then
-  echo "Cannot access to bootstrap token"
-  exit 1;
-fi
-# Limit secret visibility as much as possible
-export -n SETUP_CONSUL_TOKEN
-
-POLICY_NAME='carbonio-ws-collaboration-policy'
-POLICY_DESCRIPTION='Carbonio Workstream Collaboration policy for service and sidecar proxy'
-
-# Create or update policy for the specific service (this will be shared across cluster)
-consul acl policy create -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules  @/etc/carbonio/ws-collaboration/service-discover/policies.json >/dev/null 2>&1
-if [[ "$?" != "0" ]]; then
-    consul acl policy update -no-merge -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules @/etc/carbonio/ws-collaboration/service-discover/policies.json
-    if [[ "$?" != "0" ]]; then
-      echo "Setup failed: Cannot update policy for ${POLICY_NAME}"
-      exit 1
-    fi
-fi
-
-trap 'echo Script for Workstream Collaboration terminated with error' EXIT
-set -e
-# Declare the service as http
-consul config write /etc/carbonio/ws-collaboration/service-discover/service-protocol.json
-
-# Allow other services to contact this service
-consul config write /etc/carbonio/ws-collaboration/service-discover/intentions.json
-
-if [[ ! -f "/etc/carbonio/ws-collaboration/service-discover/token" ]]; then
-    # Create the token
-    consul acl token create -format json -policy-name "${POLICY_NAME}" -description "Token for
-    carbonio-ws-collaboration/$(hostname -A)" |
-      jq -r '.SecretID' > /etc/carbonio/ws-collaboration/service-discover/token;
-    chown carbonio-ws-collaboration:carbonio-ws-collaboration /etc/carbonio/ws-collaboration/service-discover/token
-    chmod 0600 /etc/carbonio/ws-collaboration/service-discover/token
-
-    # To pass the token to consul we need to inject it to a env. variable
-    # since it doesn't accept a file as an argument
-    mkdir -p /etc/systemd/system/carbonio-ws-collaboration.service.d/
-    cat >/etc/systemd/system/carbonio-ws-collaboration.service.d/override.conf <<EOF
-[Service]
-Environment="CONSUL_HTTP_TOKEN=$(cat /etc/carbonio/ws-collaboration/service-discover/token)"
-EOF
-    chmod 0600 /etc/systemd/system/carbonio-ws-collaboration.service.d/override.conf
-    systemctl daemon-reload
-fi
-
-consul reload
-
-carbonio-ws-collaboration-configs
-
-# Limit token visibility as much as possible
-export -n CONSUL_HTTP_TOKEN
-
-systemctl restart carbonio-ws-collaboration.service
-systemctl restart carbonio-ws-collaboration-sidecar.service
-trap - EXIT
+JAVA_HOME="/usr/share/carbonio/files:/opt/zextras/common/lib/jvm/java"
+export JAVA_HOME
+/opt/zextras/common/bin/java \
+  -Djava.net.preferIPv4Stack=true \
+  -Xms1024m \
+  -Xmx2048m \
+  -XX:+UseZGC \
+  -jar /usr/share/carbonio/carbonio-ws-collaboration.jar

--- a/package/carbonio-ws-collaboration-pending-setup
+++ b/package/carbonio-ws-collaboration-pending-setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+carbonio-ws-collaboration-setup

--- a/package/carbonio-ws-collaboration-setup
+++ b/package/carbonio-ws-collaboration-setup
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# decrypt the bootstrap token, asking the password to the sys admin
+# --setup check for SETUP_CONSUL_TOKEN env. variable and uses it
+# to avoid re-asking for the password
+if [[ $(id -u) -ne 0 ]]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+# Decrypt the bootstrap token, asking the password to the sys admin
+# --setup check for SETUP_CONSUL_TOKEN env. variable and uses it
+# to avoid re-asking for the password
+echo -n "Insert the cluster credential password: "
+# shellcheck disable=SC2155
+export CONSUL_HTTP_TOKEN=$(service-discover bootstrap-token --setup)
+EXIT_CODE="$?"
+echo ""
+if [[ "${EXIT_CODE}" != "0" ]]; then
+  echo "Cannot access to bootstrap token"
+  exit 1;
+fi
+# Limit secret visibility as much as possible
+export -n SETUP_CONSUL_TOKEN
+
+POLICY_NAME='carbonio-ws-collaboration-policy'
+POLICY_DESCRIPTION='Carbonio Workstream Collaboration policy for service and sidecar proxy'
+
+# Create or update policy for the specific service (this will be shared across cluster)
+consul acl policy create -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules  @/etc/carbonio/ws-collaboration/service-discover/policies.json >/dev/null 2>&1
+# shellcheck disable=SC2181
+if [[ "$?" != "0" ]]; then
+    consul acl policy update -no-merge -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules @/etc/carbonio/ws-collaboration/service-discover/policies.json
+    if [[ "$?" != "0" ]]; then
+      echo "Setup failed: Cannot update policy for ${POLICY_NAME}"
+      exit 1
+    fi
+fi
+
+trap 'echo Script for Workstream Collaboration terminated with error' EXIT
+set -e
+# Declare the service as http
+consul config write /etc/carbonio/ws-collaboration/service-discover/service-protocol.json
+
+# Allow other services to contact this service
+consul config write /etc/carbonio/ws-collaboration/service-discover/intentions.json
+
+if [[ ! -f "/etc/carbonio/ws-collaboration/service-discover/token" ]]; then
+    # Create the token
+    consul acl token create -format json -policy-name "${POLICY_NAME}" -description "Token for
+    carbonio-ws-collaboration/$(hostname -A)" |
+      jq -r '.SecretID' > /etc/carbonio/ws-collaboration/service-discover/token;
+    chown carbonio-ws-collaboration:carbonio-ws-collaboration /etc/carbonio/ws-collaboration/service-discover/token
+    chmod 0600 /etc/carbonio/ws-collaboration/service-discover/token
+
+    # To pass the token to consul we need to inject it to a env. variable
+    # since it doesn't accept a file as an argument
+    mkdir -p /etc/systemd/system/carbonio-ws-collaboration.service.d/
+    cat >/etc/systemd/system/carbonio-ws-collaboration.service.d/override.conf <<EOF
+[Service]
+Environment="CONSUL_HTTP_TOKEN=$(cat /etc/carbonio/ws-collaboration/service-discover/token)"
+EOF
+    chmod 0600 /etc/systemd/system/carbonio-ws-collaboration.service.d/override.conf
+    systemctl daemon-reload
+fi
+
+consul reload
+
+carbonio-ws-collaboration-configs
+
+# Limit token visibility as much as possible
+export -n CONSUL_HTTP_TOKEN
+
+systemctl restart carbonio-ws-collaboration.service
+systemctl restart carbonio-ws-collaboration-sidecar.service
+trap - EXIT

--- a/package/carbonio-ws-collaboration-setup.sh
+++ b/package/carbonio-ws-collaboration-setup.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-only
-
-/usr/bin/carbonio-ws-collaboration setup

--- a/package/carbonio-ws-collaboration.service
+++ b/package/carbonio-ws-collaboration.service
@@ -7,8 +7,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/opt/zextras/common/bin/java -Xms1024m -Xmx2048m -XX:+UseZGC\
-  -Djava.net.preferIPv4Stack=true -jar /usr/bin/carbonio/ws-collaboration/carbonio-ws-collaboration.jar
+ExecStart=/usr/bin/carbonio-ws-collaboration
 User=carbonio-ws-collaboration
 Group=carbonio-ws-collaboration
 Restart=on-failure


### PR DESCRIPTION
- Updated PKGBUILD to install jar under /usr/share/carbonio
- Renamed setup scripts and created a separated script to launch jar instead of launching it directly from service

refs: WSC-1268