### PR TITLE
feat: add cache to store videoserver session

### DIFF
--- a/carbonio-ws-collaboration-core/pom.xml
+++ b/carbonio-ws-collaboration-core/pom.xml
@@ -170,6 +170,12 @@ SPDX-License-Identifier: AGPL-3.0-only
        <artifactId>jakarta.websocket-api</artifactId>
      </dependency>
 
+    <!-- Cache -->
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
     <!-- Tests dependency -->
     <!-- JUnit Jupiter -->
     <dependency>

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/cache/CacheHandler.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/cache/CacheHandler.java
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.chats.core.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.zextras.carbonio.chats.core.data.entity.VideoServerSession;
+import java.time.Duration;
+
+@Singleton
+public class CacheHandler {
+
+  private final Cache<String, VideoServerSession> videoServerSessionCache;
+
+  @Inject
+  public CacheHandler() {
+    this.videoServerSessionCache =
+        Caffeine.newBuilder().expireAfterAccess(Duration.ofMinutes(5)).build();
+  }
+
+  public Cache<String, VideoServerSession> getVideoServerSessionCache() {
+    return videoServerSessionCache;
+  }
+}

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/repository/ParticipantRepository.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/repository/ParticipantRepository.java
@@ -10,11 +10,11 @@ import java.util.Optional;
 
 public interface ParticipantRepository {
 
+  Optional<Participant> getById(String meetingId, String userId);
+
   Optional<Participant> getByUserId(String userId);
 
   Optional<Participant> getByQueueId(String queueId);
-
-  Optional<Participant> getById(String meetingId, String userId);
 
   List<Participant> getByMeetingId(String meetingId);
 

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/repository/impl/EbeanParticipantRepository.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/repository/impl/EbeanParticipantRepository.java
@@ -24,6 +24,11 @@ public class EbeanParticipantRepository implements ParticipantRepository {
   }
 
   @Override
+  public Optional<Participant> getById(String meetingId, String userId) {
+    return Optional.ofNullable(db.find(Participant.class, ParticipantId.create(meetingId, userId)));
+  }
+
+  @Override
   public Optional<Participant> getByUserId(String userId) {
     return db.find(Participant.class).where().eq("id.userId", userId).findOneOrEmpty();
   }
@@ -31,11 +36,6 @@ public class EbeanParticipantRepository implements ParticipantRepository {
   @Override
   public Optional<Participant> getByQueueId(String queueId) {
     return db.find(Participant.class).where().eq("queue_id", queueId).findOneOrEmpty();
-  }
-
-  @Override
-  public Optional<Participant> getById(String meetingId, String userId) {
-    return Optional.ofNullable(db.find(Participant.class, ParticipantId.create(meetingId, userId)));
   }
 
   @Override

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/repository/impl/EbeanVideoServerSessionRepository.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/repository/impl/EbeanVideoServerSessionRepository.java
@@ -24,17 +24,17 @@ public class EbeanVideoServerSessionRepository implements VideoServerSessionRepo
   }
 
   @Override
+  public Optional<VideoServerSession> getById(String userId, String meetingId) {
+    return Optional.ofNullable(
+        db.find(VideoServerSession.class, new VideoServerSessionId(userId, meetingId)));
+  }
+
+  @Override
   public Optional<VideoServerSession> getByConnectionId(String connectionId) {
     return db.find(VideoServerSession.class)
         .where()
         .eq("connection_id", connectionId)
         .findOneOrEmpty();
-  }
-
-  @Override
-  public Optional<VideoServerSession> getById(String userId, String meetingId) {
-    return Optional.ofNullable(
-        db.find(VideoServerSession.class, new VideoServerSessionId(userId, meetingId)));
   }
 
   @Override

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/UserServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/UserServiceImpl.java
@@ -27,6 +27,7 @@ import com.zextras.carbonio.chats.core.repository.UserRepository;
 import com.zextras.carbonio.chats.core.service.UserService;
 import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
 import com.zextras.carbonio.chats.model.UserDto;
+import io.ebean.annotation.Transactional;
 import java.io.InputStream;
 import java.time.Clock;
 import java.time.OffsetDateTime;
@@ -72,11 +73,11 @@ public class UserServiceImpl implements UserService {
         profilingService
             .getById(currentUser, userId)
             .map(
-                profile ->
+                p ->
                     UserDto.create()
-                        .id(UUID.fromString(profile.getId()))
-                        .email(profile.getEmail())
-                        .name(profile.getName()))
+                        .id(UUID.fromString(p.getId()))
+                        .email(p.getEmail())
+                        .name(p.getName()))
             .orElseThrow(
                 () ->
                     new NotFoundException(
@@ -181,6 +182,7 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
+  @Transactional
   public void deleteUserPicture(UUID userId, UserPrincipal currentUser) {
     if (!currentUser.getUUID().equals(userId)) {
       throw new ForbiddenException("The picture can be removed only from its owner");

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/VideoServerEventListener.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/VideoServerEventListener.java
@@ -15,6 +15,7 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DeliverCallback;
 import com.rabbitmq.client.Recoverable;
 import com.rabbitmq.client.RecoveryListener;
+import com.zextras.carbonio.chats.core.cache.CacheHandler;
 import com.zextras.carbonio.chats.core.data.entity.VideoServerSession;
 import com.zextras.carbonio.chats.core.data.event.MeetingAudioAnswered;
 import com.zextras.carbonio.chats.core.data.event.MeetingMediaStreamChanged;
@@ -23,7 +24,6 @@ import com.zextras.carbonio.chats.core.data.event.MeetingParticipantTalking;
 import com.zextras.carbonio.chats.core.data.event.MeetingSdpAnswered;
 import com.zextras.carbonio.chats.core.data.event.MeetingSdpOffered;
 import com.zextras.carbonio.chats.core.exception.EventDispatcherException;
-import com.zextras.carbonio.chats.core.exception.VideoServerException;
 import com.zextras.carbonio.chats.core.infrastructure.event.EventDispatcher;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.VideoServerService;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.data.event.StreamData;
@@ -35,9 +35,11 @@ import com.zextras.carbonio.chats.core.infrastructure.videoserver.data.media.Sub
 import com.zextras.carbonio.chats.core.logging.ChatsLogger;
 import io.vavr.MatchError;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.jetbrains.annotations.NotNull;
 
 @Singleton
 public class VideoServerEventListener {
@@ -48,8 +50,8 @@ public class VideoServerEventListener {
   private static final String LOCAL = "local";
   private static final String TALKING = "talking";
   private static final String STOPPED_TALKING = "stopped-talking";
-  private static final String SUBSCRIBING_TYPE_EVENT = "subscribing";
-  private static final String UPDATED_TYPE_EVENT = "updated";
+  private static final String SUBSCRIBING = "subscribing";
+  private static final String UPDATED = "updated";
   private static final String PUBLISHED = "published";
 
   private static final int JSEP_TYPE = 8;
@@ -59,11 +61,11 @@ public class VideoServerEventListener {
   private final EventDispatcher eventDispatcher;
   private final ObjectMapper objectMapper;
   private final VideoServerService videoServerService;
+  private final CacheHandler cacheHandler;
 
   private enum EventType {
     AUDIO,
-    VIDEOIN,
-    VIDEOOUT,
+    VIDEO,
     SCREEN
   }
 
@@ -72,7 +74,16 @@ public class VideoServerEventListener {
       Channel channel,
       EventDispatcher eventDispatcher,
       ObjectMapper objectMapper,
-      VideoServerService videoServerService) {
+      VideoServerService videoServerService,
+      CacheHandler cacheHandler) {
+    this.channel = getRecoverableChannel(channel);
+    this.eventDispatcher = eventDispatcher;
+    this.objectMapper = objectMapper;
+    this.videoServerService = videoServerService;
+    this.cacheHandler = cacheHandler;
+  }
+
+  private @NotNull Channel getRecoverableChannel(Channel channel) {
     Recoverable channelRecoverable = (Recoverable) channel;
     channelRecoverable.addRecoveryListener(
         new RecoveryListener() {
@@ -87,10 +98,7 @@ public class VideoServerEventListener {
             ChatsLogger.warn("Videoserver event listener channel recovery started...");
           }
         });
-    this.channel = channel;
-    this.eventDispatcher = eventDispatcher;
-    this.objectMapper = objectMapper;
-    this.videoServerService = videoServerService;
+    return channel;
   }
 
   public void start() {
@@ -101,103 +109,104 @@ public class VideoServerEventListener {
       channel.queueDeclare(JANUS_EVENTS, false, false, false, null);
       channel.exchangeDeclare(JANUS_EXCHANGE, "direct");
       channel.queueBind(JANUS_EVENTS, JANUS_EXCHANGE, JANUS_EVENTS);
-      DeliverCallback deliverCallback =
-          (consumerTag, delivery) -> {
-            String message = new String(delivery.getBody(), StandardCharsets.UTF_8);
-            VideoServerEvent videoServerEvent =
-                objectMapper.readValue(message, VideoServerEvent.class);
-            switch (videoServerEvent.getType()) {
-              case JSEP_TYPE:
-                handleJsepTypeEvent(videoServerEvent);
-                break;
-              case PLUGIN_TYPE:
-                handleAudioBridgeEvent(videoServerEvent);
-                handleStreamsEvent(videoServerEvent);
-                break;
-              default:
-                break;
-            }
-          };
+      DeliverCallback deliverCallback = createDeliveryCallBack();
       channel.basicConsume(JANUS_EVENTS, true, deliverCallback, consumerTag -> this.start());
     } catch (Exception e) {
-      throw new VideoServerException("Error during processing video server events ", e);
+      ChatsLogger.error("Error during processing video server events ", e);
     }
   }
 
-  private void handleStreamsEvent(VideoServerEvent videoServerEvent) {
-    Optional.ofNullable(videoServerEvent.getEventInfo().getEventData().getEvent())
+  private @NotNull DeliverCallback createDeliveryCallBack() {
+    return (consumerTag, delivery) -> {
+      String message = new String(delivery.getBody(), StandardCharsets.UTF_8);
+      VideoServerEvent videoServerEvent = objectMapper.readValue(message, VideoServerEvent.class);
+      switch (videoServerEvent.getType()) {
+        case JSEP_TYPE:
+          handleJsepTypeEvent(videoServerEvent);
+          break;
+        case PLUGIN_TYPE:
+          handleAudioBridgeEvent(videoServerEvent);
+          handleStreamsEvent(videoServerEvent);
+          break;
+        default:
+          break;
+      }
+    };
+  }
+
+  private void handleJsepTypeEvent(VideoServerEvent videoServerEvent) {
+    Optional.ofNullable(videoServerEvent.getEventInfo().getOwner())
         .ifPresent(
-            eventType -> {
-              switch (eventType) {
-                case UPDATED_TYPE_EVENT, SUBSCRIBING_TYPE_EVENT:
-                  Optional.ofNullable(
-                          videoServerEvent.getEventInfo().getEventData().getStreamList())
-                      .ifPresent(
-                          streamData -> {
-                            List<StreamData> streamDataList =
-                                streamData.stream()
-                                    .filter(
-                                        stream ->
-                                            Optional.ofNullable(stream.getFeedId()).isPresent())
-                                    .toList();
-                            if (!streamDataList.isEmpty()) {
-                              videoServerService
-                                  .getSession(String.valueOf(videoServerEvent.getSessionId()))
-                                  .ifPresent(
-                                      videoServerSession ->
-                                          eventDispatcher.sendToUserExchange(
-                                              videoServerSession.getUserId(),
-                                              MeetingParticipantSubscribed.create()
-                                                  .meetingId(
-                                                      UUID.fromString(
-                                                          videoServerSession
-                                                              .getId()
-                                                              .getMeetingId()))
-                                                  .userId(
-                                                      UUID.fromString(
-                                                          videoServerSession.getUserId()))
-                                                  .streams(
-                                                      streamDataList.stream()
-                                                          .map(
-                                                              stream -> {
-                                                                Feed feed =
-                                                                    Feed.fromString(
-                                                                        stream.getFeedId());
-                                                                return SubscribedStream.create()
-                                                                    .type(
-                                                                        feed.getType()
-                                                                            .toString()
-                                                                            .toLowerCase())
-                                                                    .userId(feed.getUserId())
-                                                                    .mid(stream.getMid());
-                                                              })
-                                                          .toList())));
-                            }
-                          });
-                  break;
-                case PUBLISHED:
-                  Feed feed =
-                      Feed.fromString(videoServerEvent.getEventInfo().getEventData().getId());
-                  String meetingId =
-                      videoServerEvent.getEventInfo().getEventData().getRoom().split("_")[1];
-                  List<String> sessionUserIds =
-                      videoServerService.getSessions(meetingId).stream()
-                          .map(VideoServerSession::getUserId)
-                          .toList();
-                  eventDispatcher.sendToUserExchange(
-                      sessionUserIds,
-                      MeetingMediaStreamChanged.create()
-                          .meetingId(UUID.fromString(meetingId))
-                          .userId(UUID.fromString(feed.getUserId()))
-                          .mediaType(feed.getType())
-                          .active(
-                              PUBLISHED.equals(
-                                  videoServerEvent.getEventInfo().getEventData().getEvent())));
-                  break;
-                default:
-                  break;
+            owner -> {
+              if (LOCAL.equalsIgnoreCase(owner)) {
+                VideoServerSession videoServerSession =
+                    cacheHandler
+                        .getVideoServerSessionCache()
+                        .get(
+                            String.valueOf(videoServerEvent.getSessionId()),
+                            this::fetchVideoServerSession);
+                if (videoServerSession != null) {
+                  processRtcSessionDescription(videoServerEvent, videoServerSession);
+                }
               }
             });
+  }
+
+  private VideoServerSession fetchVideoServerSession(String sessionId) {
+    return videoServerService.getSession(sessionId).orElse(null);
+  }
+
+  private void processRtcSessionDescription(
+      VideoServerEvent videoServerEvent, VideoServerSession videoServerSession) {
+    try {
+      EventType eventType =
+          Match(videoServerEvent.getHandleId().toString())
+              .of(
+                  Case($(videoServerSession.getAudioHandleId()), EventType.AUDIO),
+                  Case($(videoServerSession.getVideoInHandleId()), EventType.VIDEO),
+                  Case($(videoServerSession.getVideoOutHandleId()), EventType.VIDEO),
+                  Case($(videoServerSession.getScreenHandleId()), EventType.SCREEN));
+      RtcSessionDescription rtcSessionDescription =
+          videoServerEvent.getEventInfo().getRtcSessionDescription();
+      switch (rtcSessionDescription.getType()) {
+        case OFFER:
+          eventDispatcher.sendToUserExchange(
+              videoServerSession.getUserId(),
+              MeetingSdpOffered.create()
+                  .meetingId(UUID.fromString(videoServerSession.getId().getMeetingId()))
+                  .userId(UUID.fromString(videoServerSession.getUserId()))
+                  .mediaType(eventType == EventType.VIDEO ? MediaType.VIDEO : MediaType.SCREEN)
+                  .sdp(rtcSessionDescription.getSdp()));
+          break;
+        case ANSWER:
+          switch (eventType) {
+            case AUDIO:
+              eventDispatcher.sendToUserExchange(
+                  videoServerSession.getUserId(),
+                  MeetingAudioAnswered.create()
+                      .meetingId(UUID.fromString(videoServerSession.getId().getMeetingId()))
+                      .userId(UUID.fromString(videoServerSession.getUserId()))
+                      .sdp(rtcSessionDescription.getSdp()));
+              break;
+            case VIDEO, SCREEN:
+              eventDispatcher.sendToUserExchange(
+                  videoServerSession.getUserId(),
+                  MeetingSdpAnswered.create()
+                      .meetingId(UUID.fromString(videoServerSession.getId().getMeetingId()))
+                      .userId(UUID.fromString(videoServerSession.getUserId()))
+                      .mediaType(eventType == EventType.VIDEO ? MediaType.VIDEO : MediaType.SCREEN)
+                      .sdp(rtcSessionDescription.getSdp()));
+              break;
+            default:
+              break;
+          }
+          break;
+        default:
+          break;
+      }
+    } catch (MatchError m) {
+      ChatsLogger.warn("Invalid event handle id: " + m.getObject());
+    }
   }
 
   private void handleAudioBridgeEvent(VideoServerEvent videoServerEvent) {
@@ -207,10 +216,7 @@ public class VideoServerEventListener {
               if (TALKING.equals(eventType) || STOPPED_TALKING.equals(eventType)) {
                 String meetingId =
                     videoServerEvent.getEventInfo().getEventData().getRoom().split("_")[1];
-                List<String> sessionUserIds =
-                    videoServerService.getSessions(meetingId).stream()
-                        .map(VideoServerSession::getUserId)
-                        .toList();
+                List<String> sessionUserIds = getMeetingVideoServerSessions(meetingId);
                 eventDispatcher.sendToUserExchange(
                     sessionUserIds,
                     MeetingParticipantTalking.create()
@@ -224,87 +230,71 @@ public class VideoServerEventListener {
             });
   }
 
-  private void handleJsepTypeEvent(VideoServerEvent videoServerEvent) {
-    Optional.ofNullable(videoServerEvent.getEventInfo().getOwner())
+  private void handleStreamsEvent(VideoServerEvent videoServerEvent) {
+    Optional.ofNullable(videoServerEvent.getEventInfo().getEventData().getEvent())
         .ifPresent(
-            owner -> {
-              if (LOCAL.equalsIgnoreCase(owner)) {
-                videoServerService
-                    .getSession(String.valueOf(videoServerEvent.getSessionId()))
-                    .ifPresent(
-                        videoServerSession -> {
-                          try {
-                            EventType eventType =
-                                Match(videoServerEvent.getHandleId().toString())
-                                    .of(
-                                        Case(
-                                            $(videoServerSession.getAudioHandleId()),
-                                            EventType.AUDIO),
-                                        Case(
-                                            $(videoServerSession.getVideoInHandleId()),
-                                            EventType.VIDEOIN),
-                                        Case(
-                                            $(videoServerSession.getVideoOutHandleId()),
-                                            EventType.VIDEOOUT),
-                                        Case(
-                                            $(videoServerSession.getScreenHandleId()),
-                                            EventType.SCREEN));
-                            RtcSessionDescription rtcSessionDescription =
-                                videoServerEvent.getEventInfo().getRtcSessionDescription();
-                            switch (rtcSessionDescription.getType()) {
-                              case OFFER:
-                                eventDispatcher.sendToUserExchange(
-                                    videoServerSession.getUserId(),
-                                    MeetingSdpOffered.create()
-                                        .meetingId(
-                                            UUID.fromString(
-                                                videoServerSession.getId().getMeetingId()))
-                                        .userId(UUID.fromString(videoServerSession.getUserId()))
-                                        .mediaType(
-                                            eventType == EventType.SCREEN
-                                                ? MediaType.SCREEN
-                                                : MediaType.VIDEO)
-                                        .sdp(rtcSessionDescription.getSdp()));
-                                break;
-                              case ANSWER:
-                                switch (eventType) {
-                                  case AUDIO:
-                                    eventDispatcher.sendToUserExchange(
-                                        videoServerSession.getUserId(),
-                                        MeetingAudioAnswered.create()
-                                            .meetingId(
-                                                UUID.fromString(
-                                                    videoServerSession.getId().getMeetingId()))
-                                            .userId(UUID.fromString(videoServerSession.getUserId()))
-                                            .sdp(rtcSessionDescription.getSdp()));
-                                    break;
-                                  case VIDEOIN, VIDEOOUT, SCREEN:
-                                    eventDispatcher.sendToUserExchange(
-                                        videoServerSession.getUserId(),
-                                        MeetingSdpAnswered.create()
-                                            .meetingId(
-                                                UUID.fromString(
-                                                    videoServerSession.getId().getMeetingId()))
-                                            .userId(UUID.fromString(videoServerSession.getUserId()))
-                                            .mediaType(
-                                                eventType == EventType.SCREEN
-                                                    ? MediaType.SCREEN
-                                                    : MediaType.VIDEO)
-                                            .sdp(rtcSessionDescription.getSdp()));
-                                    break;
-                                  default:
-                                    break;
-                                }
-                                break;
-                              default:
-                                break;
-                            }
-                          } catch (MatchError m) {
-                            throw new VideoServerException(
-                                "Invalid event handle id: " + m.getObject());
-                          }
-                        });
+            eventType -> {
+              switch (eventType) {
+                case SUBSCRIBING, UPDATED:
+                  handleUpdatedEvent(videoServerEvent);
+                  break;
+                case PUBLISHED:
+                  handlePublishedEvent(videoServerEvent);
+                  break;
+                default:
+                  break;
               }
             });
+  }
+
+  private void handleUpdatedEvent(VideoServerEvent videoServerEvent) {
+    List<StreamData> streamDataList =
+        Optional.ofNullable(videoServerEvent.getEventInfo().getEventData().getStreamList())
+            .orElse(Collections.emptyList())
+            .stream()
+            .filter(stream -> stream.getFeedId() != null)
+            .toList();
+    if (!streamDataList.isEmpty()) {
+      VideoServerSession videoServerSession =
+          cacheHandler
+              .getVideoServerSessionCache()
+              .get(String.valueOf(videoServerEvent.getSessionId()), this::fetchVideoServerSession);
+      if (videoServerSession != null) {
+        eventDispatcher.sendToUserExchange(
+            videoServerSession.getUserId(),
+            MeetingParticipantSubscribed.create()
+                .meetingId(UUID.fromString(videoServerSession.getId().getMeetingId()))
+                .userId(UUID.fromString(videoServerSession.getUserId()))
+                .streams(
+                    streamDataList.stream()
+                        .map(
+                            stream -> {
+                              Feed feed = Feed.fromString(stream.getFeedId());
+                              return SubscribedStream.create()
+                                  .type(feed.getType().toString().toLowerCase())
+                                  .userId(feed.getUserId())
+                                  .mid(stream.getMid());
+                            })
+                        .toList()));
+      }
+    }
+  }
+
+  private void handlePublishedEvent(VideoServerEvent videoServerEvent) {
+    Feed feed = Feed.fromString(videoServerEvent.getEventInfo().getEventData().getId());
+    String meetingId = videoServerEvent.getEventInfo().getEventData().getRoom().split("_")[1];
+    eventDispatcher.sendToUserExchange(
+        getMeetingVideoServerSessions(meetingId),
+        MeetingMediaStreamChanged.create()
+            .meetingId(UUID.fromString(meetingId))
+            .userId(UUID.fromString(feed.getUserId()))
+            .mediaType(feed.getType())
+            .active(PUBLISHED.equals(videoServerEvent.getEventInfo().getEventData().getEvent())));
+  }
+
+  private @NotNull List<String> getMeetingVideoServerSessions(String meetingId) {
+    return videoServerService.getSessions(meetingId).stream()
+        .map(VideoServerSession::getUserId)
+        .toList();
   }
 }

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/MeetingApiIT.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/MeetingApiIT.java
@@ -2167,6 +2167,12 @@ public class MeetingApiIT {
       videoServerMockServer.mockRequestedResponse(
           "POST",
           "/janus/connectionId_user1session1",
+          "{\"janus\":\"attach\",\"transaction\":\"${json-unit.ignore-element}\",\"plugin\":\"janus.plugin.audiobridge\",\"apisecret\":\"secret\"}",
+          "{\"janus\":\"success\", \"data\":{\"id\":\"handleId_user1session1\"}}",
+          true);
+      videoServerMockServer.mockRequestedResponse(
+          "POST",
+          "/janus/connectionId_user1session1",
           "{\"janus\":\"attach\",\"transaction\":\"${json-unit.ignore-element}\",\"plugin\":\"janus.plugin.videoroom\",\"apisecret\":\"secret\"}",
           "{\"janus\":\"success\", \"data\":{\"id\":\"handleId_user1session1\"}}",
           true);
@@ -2223,8 +2229,14 @@ public class MeetingApiIT {
           videoServerMockServer.getRequest(
               "POST",
               "/janus/connectionId_user1session1",
+              "{\"janus\":\"attach\",\"transaction\":\"${json-unit.ignore-element}\",\"plugin\":\"janus.plugin.audiobridge\",\"apisecret\":\"secret\"}"),
+          VerificationTimes.exactly(1));
+      videoServerMockServer.verify(
+          videoServerMockServer.getRequest(
+              "POST",
+              "/janus/connectionId_user1session1",
               "{\"janus\":\"attach\",\"transaction\":\"${json-unit.ignore-element}\",\"plugin\":\"janus.plugin.videoroom\",\"apisecret\":\"secret\"}"),
-          VerificationTimes.exactly(2));
+          VerificationTimes.exactly(3));
       videoServerMockServer.verify(
           videoServerMockServer.getRequest(
               "POST",
@@ -2379,6 +2391,7 @@ public class MeetingApiIT {
                   user2Queue,
                   "connection_" + user2Queue,
                   null,
+                  null,
                   null)
               .audioHandleId("audioHandleId_" + user2Queue)
               .videoInHandleId("videoInHandleId_" + user2Queue)
@@ -2522,6 +2535,7 @@ public class MeetingApiIT {
           user1Id.toString(),
           user1Queue,
           "connection_" + user1Queue,
+          null,
           null,
           null);
       videoServerMockServer.mockRequestedResponse(
@@ -2705,21 +2719,20 @@ public class MeetingApiIT {
                       .audioStreamOn(true)
                       .videoStreamOn(false)));
       meetingTestUtils.updateVideoServerSession(
-          meetingTestUtils
-              .insertVideoServerSession(
-                  meetingTestUtils.insertVideoServerMeeting(
-                      meetingId.toString(),
-                      "connectionId",
-                      "audioHandleId",
-                      "videoHandleId",
-                      "audioRoomId",
-                      "videoRoomId"),
-                  user1Id.toString(),
-                  user1Queue,
-                  "connection_" + user1Queue,
-                  null,
-                  null)
-              .videoOutHandleId("videoOutHandleId_" + user1Queue));
+          meetingTestUtils.insertVideoServerSession(
+              meetingTestUtils.insertVideoServerMeeting(
+                  meetingId.toString(),
+                  "connectionId",
+                  "audioHandleId",
+                  "videoHandleId",
+                  "audioRoomId",
+                  "videoRoomId"),
+              user1Id.toString(),
+              user1Queue,
+              "connection_" + user1Queue,
+              "videoOutHandleId_" + user1Queue,
+              null,
+              null));
       videoServerMockServer.mockRequestedResponse(
           "POST",
           "/janus/connection_" + user1Queue + "/videoOutHandleId_" + user1Queue,
@@ -2902,6 +2915,7 @@ public class MeetingApiIT {
                   user1Queue,
                   "connection_" + user1Queue,
                   null,
+                  null,
                   null)
               .videoOutStreamOn(true));
 
@@ -3026,6 +3040,7 @@ public class MeetingApiIT {
                   user1Id.toString(),
                   user1Queue,
                   "connection_" + user1Queue,
+                  null,
                   null,
                   null)
               .audioStreamOn(false));
@@ -3194,7 +3209,8 @@ public class MeetingApiIT {
                   user1Queue,
                   "connection_" + user1Queue,
                   null,
-                  "screenHandleId_" + user1Queue)
+                  null,
+                  null)
               .audioStreamOn(true));
       videoServerMockServer.mockRequestedResponse(
           "POST",
@@ -3299,7 +3315,8 @@ public class MeetingApiIT {
                   user1Id.toString(),
                   user1Queue,
                   "connection_" + user1Queue,
-                  null,
+                  "videoOutHandleId_" + user1Queue,
+                  "videoInHandleId_" + user1Queue,
                   "screenHandleId_" + user1Queue)
               .audioStreamOn(true));
       meetingTestUtils.updateVideoServerSession(
@@ -3310,7 +3327,8 @@ public class MeetingApiIT {
                   user2Queue,
                   "connection_" + user2Queue,
                   null,
-                  "screenHandleId_" + user2Queue)
+                  null,
+                  null)
               .audioStreamOn(true));
       videoServerMockServer.mockRequestedResponse(
           "POST",
@@ -3525,7 +3543,8 @@ public class MeetingApiIT {
                   user1Id.toString(),
                   user1Queue,
                   "connection_" + user1Queue,
-                  null,
+                  "videoOutHandleId_" + user1Queue,
+                  "videoInHandleId_" + user1Queue,
                   "screenHandleId_" + user1Queue)
               .screenStreamOn(false));
       videoServerMockServer.mockRequestedResponse(
@@ -3709,7 +3728,8 @@ public class MeetingApiIT {
                   user1Id.toString(),
                   user1Queue,
                   "connection_" + user1Queue,
-                  null,
+                  "videoOutHandleId_" + user1Queue,
+                  "videoInHandleId_" + user1Queue,
                   "screenHandleId_" + user1Queue)
               .screenStreamOn(true));
       MockHttpResponse response =
@@ -3842,6 +3862,7 @@ public class MeetingApiIT {
                   user1Queue,
                   "connection_" + user1Queue,
                   "videoOutHandleId_" + user1Queue,
+                  "videoInHandleId_" + user1Queue,
                   null)
               .videoOutStreamOn(true));
       meetingTestUtils.updateVideoServerSession(
@@ -3852,18 +3873,13 @@ public class MeetingApiIT {
                   user2Queue,
                   "connection_" + user2Queue,
                   "videoOutHandleId_" + user2Queue,
-                  null)
+                  "videoInHandleId_" + user2Queue,
+                  "screenHandleId_" + user2Queue)
               .videoOutStreamOn(true));
 
       videoServerMockServer.mockRequestedResponse(
           "POST",
-          "/janus/connection_" + user1Queue,
-          "{\"janus\":\"attach\",\"transaction\":\"${json-unit.ignore-element}\",\"plugin\":\"janus.plugin.videoroom\",\"apisecret\":\"secret\"}",
-          "{\"janus\":\"success\",\"data\":{\"id\":\"videoInHandleId\"}}",
-          true);
-      videoServerMockServer.mockRequestedResponse(
-          "POST",
-          "/janus/connection_" + user1Queue + "/videoInHandleId",
+          "/janus/connection_" + user1Queue + "/videoInHandleId_" + user1Queue,
           "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
               + "\"request\":\"join\",\"ptype\":\"subscriber\",\"room\":\"videoRoomId\",\"streams\":[{"
               + "\"feed\":\"82735f6d-4c6c-471e-99d9-4eef91b1ec45/video\"}]},\"apisecret\":\"secret\"}",
@@ -3886,13 +3902,7 @@ public class MeetingApiIT {
       videoServerMockServer.verify(
           videoServerMockServer.getRequest(
               "POST",
-              "/janus/connection_" + user1Queue,
-              "{\"janus\":\"attach\",\"transaction\":\"${json-unit.ignore-element}\",\"plugin\":\"janus.plugin.videoroom\",\"apisecret\":\"secret\"}"),
-          VerificationTimes.exactly(1));
-      videoServerMockServer.verify(
-          videoServerMockServer.getRequest(
-              "POST",
-              "/janus/connection_" + user1Queue + "/videoInHandleId",
+              "/janus/connection_" + user1Queue + "/videoInHandleId_" + user1Queue,
               "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
                   + "\"request\":\"join\",\"ptype\":\"subscriber\",\"room\":\"videoRoomId\",\"streams\":[{"
                   + "\"feed\":\"82735f6d-4c6c-471e-99d9-4eef91b1ec45/video\"}]},\"apisecret\":\"secret\"}"),
@@ -3942,9 +3952,10 @@ public class MeetingApiIT {
                   user1Queue,
                   "connection_" + user1Queue,
                   "videoOutHandleId_" + user1Queue,
-                  null)
+                  "videoInHandleId_" + user1Queue,
+                  "screenHandleId_" + user1Queue)
               .videoOutStreamOn(true)
-              .videoInHandleId("videoInHandleId"));
+              .videoInStreamOn(true));
       meetingTestUtils.updateVideoServerSession(
           meetingTestUtils
               .insertVideoServerSession(
@@ -3953,12 +3964,13 @@ public class MeetingApiIT {
                   user2Queue,
                   "connection_" + user2Queue,
                   "videoOutHandleId_" + user2Queue,
-                  null)
+                  "videoInHandleId_" + user2Queue,
+                  "screenHandleId_" + user2Queue)
               .videoOutStreamOn(true));
 
       videoServerMockServer.mockRequestedResponse(
           "POST",
-          "/janus/connection_" + user1Queue + "/videoInHandleId",
+          "/janus/connection_" + user1Queue + "/videoInHandleId_" + user1Queue,
           "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
               + "\"request\":\"update\","
               + "\"subscribe\":[{\"feed\":\"82735f6d-4c6c-471e-99d9-4eef91b1ec45/video\"}]},\"apisecret\":\"secret\"}",
@@ -3981,7 +3993,7 @@ public class MeetingApiIT {
       videoServerMockServer.verify(
           videoServerMockServer.getRequest(
               "POST",
-              "/janus/connection_" + user1Queue + "/videoInHandleId",
+              "/janus/connection_" + user1Queue + "/videoInHandleId_" + user1Queue,
               "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
                   + "\"request\":\"update\","
                   + "\"subscribe\":[{\"feed\":\"82735f6d-4c6c-471e-99d9-4eef91b1ec45/video\"}]},\"apisecret\":\"secret\"}"),
@@ -4035,9 +4047,10 @@ public class MeetingApiIT {
                   user1Queue,
                   "connection_" + user1Queue,
                   "videoOutHandleId_" + user1Queue,
-                  null)
+                  "videoInHandleId_" + user1Queue,
+                  "screenHandleId_" + user1Queue)
               .videoOutStreamOn(true)
-              .videoInHandleId("videoInHandleId"));
+              .videoInStreamOn(true));
       meetingTestUtils.updateVideoServerSession(
           meetingTestUtils
               .insertVideoServerSession(
@@ -4046,7 +4059,8 @@ public class MeetingApiIT {
                   user2Queue,
                   "connection_" + user2Queue,
                   "videoOutHandleId_" + user2Queue,
-                  null)
+                  "videoInHandleId_" + user2Queue,
+                  "screenHandleId_" + user2Queue)
               .videoOutStreamOn(true));
       meetingTestUtils.updateVideoServerSession(
           meetingTestUtils
@@ -4056,12 +4070,13 @@ public class MeetingApiIT {
                   user3Queue,
                   "connection_" + user3Queue,
                   "videoOutHandleId_" + user3Queue,
-                  null)
+                  "videoInHandleId_" + user3Queue,
+                  "screenHandleId_" + user3Queue)
               .videoOutStreamOn(true));
 
       videoServerMockServer.mockRequestedResponse(
           "POST",
-          "/janus/connection_" + user1Queue + "/videoInHandleId",
+          "/janus/connection_" + user1Queue + "/videoInHandleId_" + user1Queue,
           "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
               + "\"request\":\"update\",\"subscribe\":[{\"feed\":\"82735f6d-4c6c-471e-99d9-4eef91b1ec45/video\"}],"
               + "\"unsubscribe\":[{\"feed\":\"ea7b9b61-bef5-4cf4-80cb-19612c42593a/video\"}]},\"apisecret\":\"secret\"}",
@@ -4089,7 +4104,7 @@ public class MeetingApiIT {
       videoServerMockServer.verify(
           videoServerMockServer.getRequest(
               "POST",
-              "/janus/connection_" + user1Queue + "/videoInHandleId",
+              "/janus/connection_" + user1Queue + "/videoInHandleId_" + user1Queue,
               "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
                   + "\"request\":\"update\",\"subscribe\":[{\"feed\":\"82735f6d-4c6c-471e-99d9-4eef91b1ec45/video\"}],"
                   + "\"unsubscribe\":[{\"feed\":\"ea7b9b61-bef5-4cf4-80cb-19612c42593a/video\"}]},\"apisecret\":\"secret\"}"),
@@ -4138,9 +4153,10 @@ public class MeetingApiIT {
                   user1Queue,
                   "connection_" + user1Queue,
                   "videoOutHandleId_" + user1Queue,
-                  null)
+                  "videoInHandleId_" + user1Queue,
+                  "screenHandleId_" + user1Queue)
               .videoOutStreamOn(true)
-              .videoInHandleId("videoInHandleId"));
+              .videoInStreamOn(true));
       meetingTestUtils.updateVideoServerSession(
           meetingTestUtils
               .insertVideoServerSession(
@@ -4149,12 +4165,13 @@ public class MeetingApiIT {
                   user2Queue,
                   "connection_" + user2Queue,
                   "videoOutHandleId_" + user2Queue,
-                  null)
+                  "videoInHandleId_" + user2Queue,
+                  "screenHandleId_" + user2Queue)
               .videoOutStreamOn(true));
 
       videoServerMockServer.mockRequestedResponse(
           "POST",
-          "/janus/connection_" + user1Queue + "/videoInHandleId",
+          "/janus/connection_" + user1Queue + "/videoInHandleId_" + user1Queue,
           "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
               + "\"request\":\"update\","
               + "\"unsubscribe\":[{\"feed\":\"82735f6d-4c6c-471e-99d9-4eef91b1ec45/video\"}]},\"apisecret\":\"secret\"}",
@@ -4177,7 +4194,7 @@ public class MeetingApiIT {
       videoServerMockServer.verify(
           videoServerMockServer.getRequest(
               "POST",
-              "/janus/connection_" + user1Queue + "/videoInHandleId",
+              "/janus/connection_" + user1Queue + "/videoInHandleId_" + user1Queue,
               "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
                   + "\"request\":\"update\","
                   + "\"unsubscribe\":[{\"feed\":\"82735f6d-4c6c-471e-99d9-4eef91b1ec45/video\"}]},\"apisecret\":\"secret\"}"),
@@ -4278,86 +4295,9 @@ public class MeetingApiIT {
 
     @Test
     @DisplayName(
-        "It answers with rtc for media stream with new handle id for the current session and"
-            + " returns a status code 204")
-    void answerRtcMediaStream_testOkAttachNewHandleId() throws Exception {
-      integrationTestUtils.generateAndSaveRoom(
-          Room.create()
-              .id(room1Id.toString())
-              .type(RoomTypeDto.GROUP)
-              .name("name")
-              .description("description"),
-          List.of(RoomMemberField.create().id(user1Id).owner(true)));
-      UUID meetingId =
-          meetingTestUtils.generateAndSaveMeeting(
-              room1Id,
-              List.of(
-                  ParticipantBuilder.create(user1Id, user1Queue)
-                      .audioStreamOn(true)
-                      .videoStreamOn(true)));
-      VideoServerMeeting meeting =
-          meetingTestUtils.insertVideoServerMeeting(
-              meetingId.toString(),
-              "connectionId",
-              "audioHandleId",
-              "videoHandleId",
-              "audioRoomId",
-              "videoRoomId");
-      meetingTestUtils.updateVideoServerSession(
-          meetingTestUtils
-              .insertVideoServerSession(
-                  meeting,
-                  user1Id.toString(),
-                  user1Queue,
-                  "connection_" + user1Queue,
-                  "videoOutHandleId_" + user1Queue,
-                  null)
-              .videoOutStreamOn(true));
-
-      videoServerMockServer.mockRequestedResponse(
-          "POST",
-          "/janus/connection_" + user1Queue,
-          "{\"janus\":\"attach\",\"transaction\":\"${json-unit.ignore-element}\",\"plugin\":\"janus.plugin.videoroom\",\"apisecret\":\"secret\"}",
-          "{\"janus\":\"success\",\"data\":{\"id\":\"videoInHandleId\"}}",
-          true);
-      videoServerMockServer.mockRequestedResponse(
-          "POST",
-          "/janus/connection_" + user1Queue + "/videoInHandleId",
-          "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{\"request\":\"start\"},"
-              + "\"apisecret\":\"secret\",\"jsep\":{\"type\":\"ANSWER\",\"sdp\":\"sdp\"}}",
-          "{\"janus\":\"ack\"}",
-          true);
-
-      MockHttpResponse response =
-          dispatcher.put(
-              url(meetingId),
-              objectMapper.writeValueAsString(SessionDescriptionProtocolDto.create().sdp("sdp")),
-              Map.of("queue-id", user1Queue),
-              user1Token);
-
-      videoServerMockServer.verify(
-          videoServerMockServer.getRequest(
-              "POST",
-              "/janus/connection_" + user1Queue,
-              "{\"janus\":\"attach\",\"transaction\":\"${json-unit.ignore-element}\",\"plugin\":\"janus.plugin.videoroom\",\"apisecret\":\"secret\"}"),
-          VerificationTimes.exactly(1));
-      videoServerMockServer.verify(
-          videoServerMockServer.getRequest(
-              "POST",
-              "/janus/connection_" + user1Queue + "/videoInHandleId",
-              "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{\"request\":\"start\"},"
-                  + "\"apisecret\":\"secret\",\"jsep\":{\"type\":\"ANSWER\",\"sdp\":\"sdp\"}}"),
-          VerificationTimes.exactly(1));
-
-      assertEquals(204, response.getStatus());
-      assertEquals(0, response.getOutput().length);
-    }
-
-    @Test
-    @DisplayName(
         "It answers with rtc for media stream with set handle id for the current session and"
             + " returns a status code 204")
-    void answerRtcMediaStream_testOkUseSetHandleId() throws Exception {
+    void answerRtcMediaStream_testOk() throws Exception {
       integrationTestUtils.generateAndSaveRoom(
           Room.create()
               .id(room1Id.toString())
@@ -4388,7 +4328,8 @@ public class MeetingApiIT {
                   user1Queue,
                   "connection_" + user1Queue,
                   "videoOutHandleId_" + user1Queue,
-                  null)
+                  "videoInHandleId_" + user1Queue,
+                  "screenHandleId_" + user1Queue)
               .videoOutStreamOn(true)
               .videoInHandleId("videoInHandleId"));
 
@@ -4458,79 +4399,9 @@ public class MeetingApiIT {
 
     @Test
     @DisplayName(
-        "It offers with rtc for audio stream with new handle id for the current session and returns"
-            + " a status code 204")
-    void offerRtcAudioStream_testOkAttachNewHandleId() throws Exception {
-      integrationTestUtils.generateAndSaveRoom(
-          Room.create()
-              .id(room1Id.toString())
-              .type(RoomTypeDto.GROUP)
-              .name("name")
-              .description("description"),
-          List.of(RoomMemberField.create().id(user1Id).owner(true)));
-      UUID meetingId =
-          meetingTestUtils.generateAndSaveMeeting(
-              room1Id, List.of(ParticipantBuilder.create(user1Id, user1Queue)));
-      VideoServerMeeting meeting =
-          meetingTestUtils.insertVideoServerMeeting(
-              meetingId.toString(),
-              "connectionId",
-              "audioHandleId",
-              "videoHandleId",
-              "audioRoomId",
-              "videoRoomId");
-      meetingTestUtils.updateVideoServerSession(
-          meetingTestUtils.insertVideoServerSession(
-              meeting, user1Id.toString(), user1Queue, "connection_" + user1Queue, null, null));
-
-      videoServerMockServer.mockRequestedResponse(
-          "POST",
-          "/janus/connection_" + user1Queue,
-          "{\"janus\":\"attach\",\"transaction\":\"${json-unit.ignore-element}\",\"plugin\":\"janus.plugin.audiobridge\",\"apisecret\":\"secret\"}",
-          "{\"janus\":\"success\",\"data\":{\"id\":\"audioHandleId\"}}",
-          true);
-      videoServerMockServer.mockRequestedResponse(
-          "POST",
-          "/janus/connection_" + user1Queue + "/audioHandleId",
-          "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
-              + "\"request\":\"join\",\"room\":\"audioRoomId\",\"id\":\"332a9527-3388-4207-be77-6d7e2978a723\",\"muted\":true,"
-              + "\"filename\":\"${json-unit.ignore-element}\"},"
-              + "\"apisecret\":\"secret\",\"jsep\":{\"type\":\"OFFER\",\"sdp\":\"sdp\"}}",
-          "{\"janus\":\"ack\"}",
-          true);
-
-      MockHttpResponse response =
-          dispatcher.put(
-              url(meetingId),
-              objectMapper.writeValueAsString(SessionDescriptionProtocolDto.create().sdp("sdp")),
-              Map.of("queue-id", user1Queue),
-              user1Token);
-
-      videoServerMockServer.verify(
-          videoServerMockServer.getRequest(
-              "POST",
-              "/janus/connection_" + user1Queue,
-              "{\"janus\":\"attach\",\"transaction\":\"${json-unit.ignore-element}\",\"plugin\":\"janus.plugin.audiobridge\",\"apisecret\":\"secret\"}"),
-          VerificationTimes.exactly(1));
-      videoServerMockServer.verify(
-          videoServerMockServer.getRequest(
-              "POST",
-              "/janus/connection_" + user1Queue + "/audioHandleId",
-              "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
-                  + "\"request\":\"join\",\"room\":\"audioRoomId\",\"id\":\"332a9527-3388-4207-be77-6d7e2978a723\",\"muted\":true,"
-                  + "\"filename\":\"${json-unit.ignore-element}\"},"
-                  + "\"apisecret\":\"secret\",\"jsep\":{\"type\":\"OFFER\",\"sdp\":\"sdp\"}}"),
-          VerificationTimes.exactly(1));
-
-      assertEquals(204, response.getStatus());
-      assertEquals(0, response.getOutput().length);
-    }
-
-    @Test
-    @DisplayName(
         "It offers with rtc for audio stream with set handle id for the current session and returns"
             + " a status code 204")
-    void offerRtcAudioStream_testOkUseSetHandleId() throws Exception {
+    void offerRtcAudioStream_testOk() throws Exception {
       integrationTestUtils.generateAndSaveRoom(
           Room.create()
               .id(room1Id.toString())
@@ -4552,12 +4423,18 @@ public class MeetingApiIT {
       meetingTestUtils.updateVideoServerSession(
           meetingTestUtils
               .insertVideoServerSession(
-                  meeting, user1Id.toString(), user1Queue, "connection_" + user1Queue, null, null)
-              .audioHandleId("audioHandleId"));
+                  meeting,
+                  user1Id.toString(),
+                  user1Queue,
+                  "connection_" + user1Queue,
+                  null,
+                  null,
+                  null)
+              .audioHandleId("audioHandleId_" + user1Queue));
 
       videoServerMockServer.mockRequestedResponse(
           "POST",
-          "/janus/connection_" + user1Queue + "/audioHandleId",
+          "/janus/connection_" + user1Queue + "/audioHandleId_" + user1Queue,
           "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
               + "\"request\":\"join\",\"room\":\"audioRoomId\",\"id\":\"332a9527-3388-4207-be77-6d7e2978a723\",\"muted\":true,"
               + "\"filename\":\"${json-unit.ignore-element}\"},"
@@ -4575,7 +4452,7 @@ public class MeetingApiIT {
       videoServerMockServer.verify(
           videoServerMockServer.getRequest(
               "POST",
-              "/janus/connection_" + user1Queue + "/audioHandleId",
+              "/janus/connection_" + user1Queue + "/audioHandleId_" + user1Queue,
               "{\"janus\":\"message\",\"transaction\":\"${json-unit.ignore-element}\",\"body\":{"
                   + "\"request\":\"join\",\"room\":\"audioRoomId\",\"id\":\"332a9527-3388-4207-be77-6d7e2978a723\",\"muted\":true,"
                   + "\"filename\":\"${json-unit.ignore-element}\"},"

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/RoomsApiIT.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/RoomsApiIT.java
@@ -2838,6 +2838,7 @@ public class RoomsApiIT {
                   user2Queue,
                   "connection_" + user2Queue,
                   null,
+                  null,
                   null)
               .audioHandleId("audioHandleId_" + user2Queue));
       videoServerMockServer.mockRequestedResponse(
@@ -2935,6 +2936,7 @@ public class RoomsApiIT {
                   user2Id.toString(),
                   user2Queue,
                   "connection_" + user2Queue,
+                  null,
                   null,
                   null)
               .audioHandleId("audioHandleId_" + user2Queue));

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/utils/MeetingTestUtils.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/utils/MeetingTestUtils.java
@@ -93,11 +93,13 @@ public class MeetingTestUtils {
       String queueId,
       String connectionId,
       String videoOutHandleId,
+      String videoInHandleId,
       String screenHandleId) {
     return videoServerSessionRepository.insert(
         VideoServerSession.create(userId, queueId, videoServerMeeting)
             .connectionId(connectionId)
             .videoOutHandleId(videoOutHandleId)
+            .videoInHandleId(videoInHandleId)
             .screenHandleId(screenHandleId));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,9 @@ SPDX-License-Identifier: AGPL-3.0-only
     <com.rabbitmq.amqp-client.version>5.21.0</com.rabbitmq.amqp-client.version>
     <!-- Web Socket -->
     <jakarta.websocket-api.version>2.0.0</jakarta.websocket-api.version>
+    <caffeine.cache.version>3.1.8</caffeine.cache.version>
     <jakarta.el>5.0.0-M1</jakarta.el>
+
     <!-- Tests dependency -->
     <!-- JUnit Jupiter -->
     <org.junit.jupiter.version>5.8.2</org.junit.jupiter.version>
@@ -111,7 +113,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-
     <ebean-maven-plugin.version>13.6.5</ebean-maven-plugin.version>
   </properties>
 
@@ -402,6 +403,13 @@ SPDX-License-Identifier: AGPL-3.0-only
         <groupId>com.rabbitmq</groupId>
         <artifactId>amqp-client</artifactId>
         <version>${com.rabbitmq.amqp-client.version}</version>
+      </dependency>
+
+      <!-- Cache -->
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>${caffeine.cache.version}</version>
       </dependency>
 
       <!-- Tests dependency -->


### PR DESCRIPTION
this is very useful for the videoserver event listener
which has to retrieve data from db for every single event.

* chore: refactor VideoServerEventListener
* chore: set videoInHandleId when video server session is created
this simplifies the process of updating subscriptions
* chore: set audioHandleId when the video server session is created
this is necessary to avoid race condition on the VideoServerEventListener with the cache

refs: WSC-1611