### PR TITLE
fix: close streams after files are retrieved by clients using StreamingOutput

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,9 @@ pipeline {
     booleanParam defaultValue: false,
     description: 'Whether to upload the packages in playground repository',
     name: 'PLAYGROUND'
+    booleanParam defaultValue: false,
+    description: 'Whether to run the dependency check',
+    name: 'DEPENDENCY_CHECK'
   }
   options {
     skipDefaultCheckout()
@@ -78,7 +81,10 @@ pipeline {
         }
       }
     }
-    stage('Dependency check'){
+    stage('Dependency check') {
+      when {
+        expression { params.DEPENDENCY_CHECK == true }
+      }
       steps {
         dependencyCheck additionalArguments: '''
           -o "./"

--- a/carbonio-ws-collaboration-boot/pom.xml
+++ b/carbonio-ws-collaboration-boot/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.ws-collaboration</groupId>
     <artifactId>carbonio-ws-collaboration-ce</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.1</version>
   </parent>
 
   <artifactId>carbonio-ws-collaboration-ce-boot</artifactId>

--- a/carbonio-ws-collaboration-core/pom.xml
+++ b/carbonio-ws-collaboration-core/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.ws-collaboration</groupId>
     <artifactId>carbonio-ws-collaboration-ce</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.1</version>
   </parent>
 
   <artifactId>carbonio-ws-collaboration-ce-core</artifactId>

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/data/model/FileContentAndMetadata.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/data/model/FileContentAndMetadata.java
@@ -5,11 +5,17 @@
 package com.zextras.carbonio.chats.core.data.model;
 
 import com.zextras.carbonio.chats.core.data.entity.FileMetadata;
+import com.zextras.carbonio.chats.core.logging.ChatsLogger;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.StreamingOutput;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.commons.io.IOUtils;
 
-public class FileContentAndMetadata {
+public class FileContentAndMetadata implements StreamingOutput {
 
-  private final InputStream  fileStream;
+  private final InputStream fileStream;
   private final FileMetadata metadata;
 
   public FileContentAndMetadata(InputStream fileStream, FileMetadata metadata) {
@@ -23,5 +29,23 @@ public class FileContentAndMetadata {
 
   public FileMetadata getMetadata() {
     return metadata;
+  }
+
+  @Override
+  public void write(OutputStream outputStream) throws WebApplicationException {
+    try {
+      IOUtils.copyLarge(fileStream, outputStream);
+    } catch (IOException e) {
+      ChatsLogger.warn("Error occurred on the file stream " + metadata.getId(), e);
+      throw new WebApplicationException("File streaming failed for " + metadata.getId(), e);
+    } finally {
+      if (fileStream != null) {
+        try {
+          fileStream.close();
+        } catch (IOException e) {
+          ChatsLogger.error("Failed to close the file stream " + metadata.getId(), e);
+        }
+      }
+    }
   }
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/event/impl/EventDispatcherRabbitMq.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/event/impl/EventDispatcherRabbitMq.java
@@ -53,7 +53,7 @@ public class EventDispatcherRabbitMq implements EventDispatcher {
   @Override
   public void sendToUserQueue(String userId, String queueId, DomainEvent event) {
     if (channel == null || !channel.isOpen()) {
-      ChatsLogger.error("Event dispatcher channel is not up!");
+      ChatsLogger.error("Unable to send event to user queue: event dispatcher channel is not up!");
       return;
     }
     String queueName = userId + "/" + queueId;
@@ -71,7 +71,7 @@ public class EventDispatcherRabbitMq implements EventDispatcher {
 
   private void sendToExchange(String userId, String event) {
     if (channel == null || !channel.isOpen()) {
-      ChatsLogger.error("Event dispatcher channel is not up!");
+      ChatsLogger.error("Unable to send event to exchange: event dispatcher channel is not up!");
       return;
     }
     try {

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/MessageDispatcher.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/MessageDispatcher.java
@@ -97,7 +97,10 @@ public interface MessageDispatcher extends HealthIndicator {
    *
    * @param roomId room identifier
    * @param senderId operation user identifier
-   * @param metadata file properties {@link FileMetadata}
+   * @param fileId identifier of the file
+   * @param fileName name of the file
+   * @param mimeType mime type of the file
+   * @param originalSize size of the file
    * @param description description of the attachment
    * @param messageId identifier of XMPP message to create
    * @param replyId identifier of the message being replied to
@@ -106,7 +109,10 @@ public interface MessageDispatcher extends HealthIndicator {
   void sendAttachment(
       String roomId,
       String senderId,
-      FileMetadata metadata,
+      String fileId,
+      String fileName,
+      String mimeType,
+      long originalSize,
       String description,
       @Nullable String messageId,
       @Nullable String replyId,

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/MessageDispatcherMongooseImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/MessageDispatcherMongooseImpl.java
@@ -289,7 +289,10 @@ public class MessageDispatcherMongooseImpl implements MessageDispatcher {
   public void sendAttachment(
       String roomId,
       String senderId,
-      FileMetadata metadata,
+      String fileId,
+      String fileName,
+      String mimeType,
+      long originalSize,
       String description,
       @Nullable String messageId,
       @Nullable String replyId,
@@ -297,10 +300,10 @@ public class MessageDispatcherMongooseImpl implements MessageDispatcher {
     XmppMessageBuilder xmppMsgBuilder =
         XmppMessageBuilder.create(roomIdToRoomDomain(roomId), userIdToUserDomain(senderId))
             .type(MessageType.ATTACHMENT_ADDED)
-            .addConfig(ATTACHMENT_ID, metadata.getId())
-            .addConfig("filename", StringFormatUtils.encodeToUtf8(metadata.getName()), true)
-            .addConfig("mime-type", metadata.getMimeType())
-            .addConfig("size", String.valueOf(metadata.getOriginalSize()))
+            .addConfig(ATTACHMENT_ID, fileId)
+            .addConfig("filename", StringFormatUtils.encodeToUtf8(fileName), true)
+            .addConfig("mime-type", mimeType)
+            .addConfig("size", String.valueOf(originalSize))
             .body(description)
             .messageId(messageId)
             .replyId(replyId);

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/storage/StoragesService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/storage/StoragesService.java
@@ -4,7 +4,6 @@
 
 package com.zextras.carbonio.chats.core.infrastructure.storage;
 
-import com.zextras.carbonio.chats.core.data.entity.FileMetadata;
 import com.zextras.carbonio.chats.core.infrastructure.HealthIndicator;
 import java.io.InputStream;
 import java.util.List;
@@ -23,11 +22,12 @@ public interface StoragesService extends HealthIndicator {
   /**
    * Saves a file on the repository
    *
-   * @param file file stream to save {@link InputStream}
-   * @param metadata file metadata {@link FileMetadata}
-   * @param currentUserId identifier of the current user
+   * @param file {@link InputStream} file stream to save {@link InputStream}
+   * @param fileId identifier of the file
+   * @param ownerId identifier of the owner of this file
+   * @param originalSize size of the file
    */
-  void saveFile(InputStream file, FileMetadata metadata, String currentUserId);
+  void saveFile(InputStream file, String fileId, String ownerId, long originalSize);
 
   /**
    * Copies a file
@@ -52,8 +52,8 @@ public interface StoragesService extends HealthIndicator {
    * Deletes file list by their identifiers
    *
    * @param fileIds identifiers list of files to delete
-   * @param currentUserId identifier of the current user
+   * @param ownerId identifier of the owner of the files
    * @return identifiers list of files deleted
    */
-  List<String> deleteFileList(List<String> fileIds, String currentUserId);
+  List<String> deleteFileList(List<String> fileIds, String ownerId);
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/storage/impl/StoragesServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/storage/impl/StoragesServiceImpl.java
@@ -6,7 +6,6 @@ package com.zextras.carbonio.chats.core.infrastructure.storage.impl;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.zextras.carbonio.chats.core.data.entity.FileMetadata;
 import com.zextras.carbonio.chats.core.exception.StorageException;
 import com.zextras.carbonio.chats.core.infrastructure.storage.StoragesService;
 import com.zextras.filestore.api.Filestore.Liveness;
@@ -39,10 +38,9 @@ public class StoragesServiceImpl implements StoragesService {
   }
 
   @Override
-  public void saveFile(InputStream file, FileMetadata metadata, String currentUserId) {
+  public void saveFile(InputStream file, String fileId, String ownerId, long originalSize) {
     try {
-      storagesClient.uploadPut(
-          ChatsIdentifier.of(metadata.getId(), currentUserId), file, metadata.getOriginalSize());
+      storagesClient.uploadPut(ChatsIdentifier.of(fileId, ownerId), file, originalSize);
     } catch (Exception e) {
       throw new StorageException("An error occurred while uploading the file", e);
     }
@@ -71,14 +69,14 @@ public class StoragesServiceImpl implements StoragesService {
   }
 
   @Override
-  public List<String> deleteFileList(List<String> fileIds, String currentUserId) {
+  public List<String> deleteFileList(List<String> fileIds, String ownerId) {
     try {
       return fileIds.isEmpty()
           ? List.of()
           : storagesClient
               .bulkDelete(
                   IdentifierType.chats,
-                  currentUserId,
+                  ownerId,
                   fileIds.stream().map(BulkDeleteRequestItem::chatsItem).toList())
               .stream()
               .map(BulkDeleteResponseItem::getNode)

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/api/AttachmentsApiServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/api/AttachmentsApiServiceImpl.java
@@ -8,9 +8,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.zextras.carbonio.chats.api.AttachmentsApiService;
 import com.zextras.carbonio.chats.core.data.model.FileContentAndMetadata;
-import com.zextras.carbonio.chats.core.exception.StorageException;
 import com.zextras.carbonio.chats.core.exception.UnauthorizedException;
-import com.zextras.carbonio.chats.core.infrastructure.storage.StoragesService;
 import com.zextras.carbonio.chats.core.logging.ChatsLoggerLevel;
 import com.zextras.carbonio.chats.core.logging.annotation.TimedCall;
 import com.zextras.carbonio.chats.core.service.AttachmentService;
@@ -24,28 +22,22 @@ import java.util.UUID;
 @Singleton
 public class AttachmentsApiServiceImpl implements AttachmentsApiService {
 
-  private final StoragesService storagesService;
   private final AttachmentService attachmentService;
 
   @Inject
-  public AttachmentsApiServiceImpl(
-      AttachmentService attachmentService, StoragesService storagesService) {
+  public AttachmentsApiServiceImpl(AttachmentService attachmentService) {
     this.attachmentService = attachmentService;
-    this.storagesService = storagesService;
   }
 
   @Override
   @TimedCall(logLevel = ChatsLoggerLevel.INFO)
   public Response getAttachment(UUID fileId, SecurityContext securityContext) {
-    if (!storagesService.isAlive()) {
-      throw new StorageException("Storage service is not alive");
-    }
     UserPrincipal currentUser =
         Optional.ofNullable((UserPrincipal) securityContext.getUserPrincipal())
             .orElseThrow(UnauthorizedException::new);
     FileContentAndMetadata attachment = attachmentService.getAttachmentById(fileId, currentUser);
     return Response.status(Status.OK)
-        .entity(attachment.getFileStream())
+        .entity(attachment)
         .header("Content-Type", attachment.getMetadata().getMimeType())
         .header("Content-Length", attachment.getMetadata().getOriginalSize())
         .header(

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/api/RoomsApiServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/api/RoomsApiServiceImpl.java
@@ -150,7 +150,7 @@ public class RoomsApiServiceImpl implements RoomsApiService {
             .orElseThrow(UnauthorizedException::new);
     FileContentAndMetadata roomPicture = roomService.getRoomPicture(roomId, currentUser);
     return Response.status(Status.OK)
-        .entity(roomPicture.getFileStream())
+        .entity(roomPicture)
         .header("Content-Type", roomPicture.getMetadata().getMimeType())
         .header("Content-Length", roomPicture.getMetadata().getOriginalSize())
         .header(
@@ -359,13 +359,6 @@ public class RoomsApiServiceImpl implements RoomsApiService {
     }
   }
 
-  /**
-   * Gets the meeting of requested room
-   *
-   * @param roomId          room identifier
-   * @param securityContext security context created by the authentication filter {@link SecurityContext}
-   * @return a response {@link Response) with status 200 and the requested meeting {@link com.zextras.carbonio.meeting.model.MeetingDto } in the body
-   */
   @Override
   public Response getMeetingByRoomId(UUID roomId, SecurityContext securityContext) {
     UserPrincipal currentUser =

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/api/UsersApiServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/api/UsersApiServiceImpl.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 @Singleton
 public class UsersApiServiceImpl implements UsersApiService {
 
-  private final int MAX_USER_IDS = 10;
   private final UserService userService;
   private final CapabilityService capabilityService;
 
@@ -53,7 +52,7 @@ public class UsersApiServiceImpl implements UsersApiService {
             .orElseThrow(UnauthorizedException::new);
     FileContentAndMetadata picture = userService.getUserPicture(userId, currentUser);
     return Response.status(Status.OK)
-        .entity(picture.getFileStream())
+        .entity(picture)
         .header("Content-Type", picture.getMetadata().getMimeType())
         .header("Content-Length", picture.getMetadata().getOriginalSize())
         .header(
@@ -68,7 +67,7 @@ public class UsersApiServiceImpl implements UsersApiService {
         Optional.ofNullable((UserPrincipal) securityContext.getUserPrincipal())
             .orElseThrow(UnauthorizedException::new);
 
-    return (userIds.isEmpty() || userIds.size() > MAX_USER_IDS)
+    return (userIds.isEmpty() || userIds.size() > 10)
         ? Response.status(Status.BAD_REQUEST).build()
         : Response.status(Status.OK)
             .entity(userService.getUsersByIds(userIds, currentUser))

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/EventsWebSocketEndpoint.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/EventsWebSocketEndpoint.java
@@ -54,7 +54,9 @@ public class EventsWebSocketEndpoint {
         .getBasicRemote()
         .sendObject(objectMapper.writeValueAsString(SessionOutEvent.create(queueId)));
     if (channel == null || !channel.isOpen()) {
-      ChatsLogger.error("Event websocket handler channel is not up!");
+      ChatsLogger.error(
+          String.format(
+              "Unable to open session %s: event websocket handler channel is not up!", queueId));
       return;
     }
     try {
@@ -131,13 +133,15 @@ public class EventsWebSocketEndpoint {
     UUID queueId = UUID.fromString(session.getId());
     String userQueue = userId + "/" + queueId;
     if (channel == null || !channel.isOpen()) {
-      ChatsLogger.error("Event websocket handler channel is not up!");
+      ChatsLogger.error(
+          String.format(
+              "Unable to close session %s: event websocket handler channel is not up!", queueId));
       return;
     }
     try {
       channel.queueDelete(userQueue);
     } catch (Exception e) {
-      ChatsLogger.warn(String.format("Error deleting queue for user/queue '%s'", userQueue));
+      ChatsLogger.warn(String.format("Error deleting queue for user/queue '%s'", userQueue), e);
     }
     participantService.removeMeetingParticipant(queueId);
   }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/provider/impl/AppInfoProviderImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/provider/impl/AppInfoProviderImplTest.java
@@ -27,6 +27,6 @@ class AppInfoProviderImplTest {
   void getVersion_testOk() {
     Optional<String> version = appInfoProvider.getVersion();
     assertTrue(version.isPresent());
-    assertEquals("0.6.0", version.get());
+    assertEquals("0.7.1", version.get());
   }
 }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/AttachmentServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/AttachmentServiceImplTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +31,6 @@ import com.zextras.carbonio.chats.core.data.model.FileContentAndMetadata;
 import com.zextras.carbonio.chats.core.data.model.PaginationFilter;
 import com.zextras.carbonio.chats.core.data.type.FileMetadataType;
 import com.zextras.carbonio.chats.core.exception.ForbiddenException;
-import com.zextras.carbonio.chats.core.exception.InternalErrorException;
 import com.zextras.carbonio.chats.core.exception.NotFoundException;
 import com.zextras.carbonio.chats.core.exception.StorageException;
 import com.zextras.carbonio.chats.core.infrastructure.messaging.MessageDispatcher;
@@ -53,6 +53,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -112,8 +113,8 @@ public class AttachmentServiceImplTest {
   }
 
   @Nested
-  @DisplayName("Gets attachment info by room id tests")
-  class GetsAllRoomAttachmentInfoTests {
+  @DisplayName("Get attachment info by room id tests")
+  class GetAttachmentInfoTests {
 
     @Test
     @DisplayName("Returns a single page of attachments info of the required room")
@@ -324,20 +325,20 @@ public class AttachmentServiceImplTest {
       UUID attachmentUuid = UUID.randomUUID();
       UserPrincipal currentUser = UserPrincipal.create(user2Id);
 
+      FileMetadata fileMetadata =
+          FileMetadataBuilder.create()
+              .id(attachmentUuid.toString())
+              .name("image1.jpg")
+              .originalSize(0L)
+              .mimeType("image/jpg")
+              .type(FileMetadataType.ATTACHMENT)
+              .userId(user1Id.toString())
+              .roomId(roomId.toString())
+              .createdAt(OffsetDateTime.now())
+              .updatedAt(OffsetDateTime.now())
+              .build();
       when(fileMetadataRepository.getById(attachmentUuid.toString()))
-          .thenReturn(
-              Optional.of(
-                  FileMetadataBuilder.create()
-                      .id(attachmentUuid.toString())
-                      .name("image1.jpg")
-                      .originalSize(0L)
-                      .mimeType("image/jpg")
-                      .type(FileMetadataType.ATTACHMENT)
-                      .userId(user1Id.toString())
-                      .roomId(roomId.toString())
-                      .createdAt(OffsetDateTime.now())
-                      .updatedAt(OffsetDateTime.now())
-                      .build()));
+          .thenReturn(Optional.of(fileMetadata));
 
       when(storagesService.getFileStreamById(attachmentUuid.toString(), user1Id.toString()))
           .thenReturn(mock(InputStream.class));
@@ -348,8 +349,11 @@ public class AttachmentServiceImplTest {
       assertNotNull(attachmentById.getFileStream());
       assertNotNull(attachmentById.getMetadata());
       assertEquals(attachmentUuid.toString(), attachmentById.getMetadata().getId());
+      verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
       verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
-      verifyNoMoreInteractions(roomService);
+      verify(storagesService, times(1))
+          .getFileStreamById(attachmentUuid.toString(), user1Id.toString());
+      verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
     }
 
     @Test
@@ -364,8 +368,12 @@ public class AttachmentServiceImplTest {
               NotFoundException.class,
               () -> attachmentService.getAttachmentById(attachmentUuid, currentUser));
       assertEquals(
-          String.format("Not Found - File with id '%s' not found", attachmentUuid),
+          String.format("Not Found - Attachment '%s' not found", attachmentUuid),
           notFoundException.getMessage());
+
+      verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
+      verifyNoMoreInteractions(fileMetadataRepository);
+      verifyNoInteractions(roomService, storagesService);
     }
 
     @Test
@@ -393,6 +401,11 @@ public class AttachmentServiceImplTest {
       assertThrows(
           ForbiddenException.class,
           () -> attachmentService.getAttachmentById(attachmentUuid, currentUser));
+
+      verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verifyNoMoreInteractions(fileMetadataRepository, roomService);
+      verifyNoInteractions(storagesService);
     }
 
     @Test
@@ -422,11 +435,16 @@ public class AttachmentServiceImplTest {
               NotFoundException.class,
               () -> attachmentService.getAttachmentById(attachmentUuid, currentUser));
       assertEquals("Not Found - Not Found", notFoundException.getMessage());
+
+      verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verifyNoMoreInteractions(fileMetadataRepository, roomService);
+      verifyNoInteractions(storagesService);
     }
 
     @Test
-    @DisplayName("Re throws an exception if the file is not found")
-    void getAttachmentById_testFileNotFound() {
+    @DisplayName("Re throws an exception if storages service throws an exception")
+    void getAttachmentById_testStorageException() {
       UUID attachmentUuid = UUID.randomUUID();
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
       when(fileMetadataRepository.getById(attachmentUuid.toString()))
@@ -444,12 +462,16 @@ public class AttachmentServiceImplTest {
                       .updatedAt(OffsetDateTime.now())
                       .build()));
       when(storagesService.getFileStreamById(attachmentUuid.toString(), user1Id.toString()))
-          .thenThrow(new InternalErrorException());
+          .thenThrow(new StorageException());
       assertThrows(
-          InternalErrorException.class,
+          StorageException.class,
           () -> attachmentService.getAttachmentById(attachmentUuid, currentUser));
+
+      verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
       verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
-      verifyNoMoreInteractions(roomService);
+      verify(storagesService, times(1))
+          .getFileStreamById(attachmentUuid.toString(), user1Id.toString());
+      verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
     }
   }
 
@@ -498,7 +520,7 @@ public class AttachmentServiceImplTest {
               NotFoundException.class,
               () -> attachmentService.getAttachmentInfoById(attachmentUuid, currentUser));
       assertEquals(
-          String.format("Not Found - File with id '%s' not found", attachmentUuid),
+          String.format("Not Found - Attachment '%s' not found", attachmentUuid),
           notFoundException.getMessage());
     }
 
@@ -571,7 +593,7 @@ public class AttachmentServiceImplTest {
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
       when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
       InputStream fileStream = mock(InputStream.class);
-      FileMetadataBuilder metadataBulder =
+      FileMetadataBuilder metadataBuilder =
           FileMetadataBuilder.create()
               .id(attachmentUuid.toString())
               .name("temp.pdf")
@@ -580,10 +602,9 @@ public class AttachmentServiceImplTest {
               .type(FileMetadataType.ATTACHMENT)
               .userId(user1Id.toString())
               .roomId(roomId.toString());
-      FileMetadata expectedMetadata = metadataBulder.build();
-      FileMetadata savedMetadata = metadataBulder.clone().createdAt(attachmentDate).build();
+      FileMetadata expectedMetadata = metadataBuilder.build();
+      FileMetadata savedMetadata = metadataBuilder.clone().createdAt(attachmentDate).build();
       when(fileMetadataRepository.save(expectedMetadata)).thenReturn(savedMetadata);
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
       try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
         uuid.when(UUID::randomUUID).thenReturn(attachmentUuid);
         uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
@@ -602,17 +623,16 @@ public class AttachmentServiceImplTest {
             currentUser);
       }
 
-      verify(storagesService, times(1)).saveFile(fileStream, savedMetadata, currentUser.toString());
-      verifyNoMoreInteractions(storagesService);
-      verify(fileMetadataRepository, times(1)).save(expectedMetadata);
-      verifyNoMoreInteractions(fileMetadataRepository);
       verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
-      verifyNoMoreInteractions(roomService);
+      verify(storagesService, times(1))
+          .saveFile(fileStream, attachmentUuid.toString(), currentUser.toString(), 1024L);
+      verify(fileMetadataRepository, times(1)).save(expectedMetadata);
+      verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
     }
 
     @Test
-    @DisplayName("Re throws an exception if the user is not a member of the room")
-    void addAttachment_testRoomNotFound() {
+    @DisplayName("Re throws an exception if the room is not found")
+    void addAttachment_testErrorRoomNotFound() {
       UUID attachmentUuid = UUID.randomUUID();
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
       InputStream fileStream = mock(InputStream.class);
@@ -621,28 +641,29 @@ public class AttachmentServiceImplTest {
       try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
         uuid.when(UUID::randomUUID).thenReturn(attachmentUuid);
         uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
-        NotFoundException notFoundException =
-            assertThrows(
-                NotFoundException.class,
-                () ->
-                    attachmentService.addAttachment(
-                        roomId,
-                        fileStream,
-                        "application/pdf",
-                        1024L,
-                        "temp.pdf",
-                        "description",
-                        null,
-                        null,
-                        null,
-                        currentUser));
-        assertEquals("Not Found - Not Found", notFoundException.getMessage());
+        assertThrows(
+            NotFoundException.class,
+            () ->
+                attachmentService.addAttachment(
+                    roomId,
+                    fileStream,
+                    "application/pdf",
+                    1024L,
+                    "temp.pdf",
+                    "description",
+                    null,
+                    null,
+                    null,
+                    currentUser));
       }
+
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
     }
 
     @Test
     @DisplayName("Re throws an exception if the user is not a member of the room")
-    void addAttachment_testForbidden() {
+    void addAttachment_testErrorForbiddenException() {
       UUID attachmentUuid = UUID.randomUUID();
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
       InputStream fileStream = mock(InputStream.class);
@@ -666,34 +687,26 @@ public class AttachmentServiceImplTest {
                     null,
                     currentUser));
       }
+
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
     }
 
     @Test
-    @DisplayName("Re throws an exception if storages throws an exception")
-    void addAttachment_testInternalException() {
+    @DisplayName("Re throws an exception if storages service throws an exception")
+    void addAttachment_testStorageException() {
       UUID attachmentUuid = UUID.randomUUID();
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
       InputStream fileStream = mock(InputStream.class);
-      FileMetadata expectedMetadata =
-          FileMetadataBuilder.create()
-              .id(attachmentUuid.toString())
-              .name("temp.pdf")
-              .originalSize(1024L)
-              .mimeType("application/pdf")
-              .type(FileMetadataType.ATTACHMENT)
-              .userId(user1Id.toString())
-              .roomId(roomId.toString())
-              .build();
       when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
-      when(fileMetadataRepository.save(expectedMetadata)).thenReturn(expectedMetadata);
-      doThrow(new InternalErrorException())
+      doThrow(new StorageException())
           .when(storagesService)
-          .saveFile(fileStream, expectedMetadata, user1Id.toString());
+          .saveFile(fileStream, attachmentUuid.toString(), user1Id.toString(), 1024L);
       try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
         uuid.when(UUID::randomUUID).thenReturn(attachmentUuid);
         uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
         assertThrows(
-            InternalErrorException.class,
+            StorageException.class,
             () ->
                 attachmentService.addAttachment(
                     roomId,
@@ -707,6 +720,177 @@ public class AttachmentServiceImplTest {
                     null,
                     currentUser));
       }
+
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(storagesService, times(1))
+          .saveFile(fileStream, attachmentUuid.toString(), currentUser.getId(), 1024L);
+      verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
+    }
+  }
+
+  @Nested
+  @DisplayName("Copy attachment tests")
+  class CopyAttachmentTests {
+
+    @Test
+    @DisplayName("Copies the attachment and returns it")
+    void copyAttachment_testOk() {
+      UserPrincipal currentUser = UserPrincipal.create(user1Id);
+      UUID originalAttachmentId = UUID.randomUUID();
+      FileMetadataBuilder metadataBuilder =
+          FileMetadataBuilder.create()
+              .id(originalAttachmentId.toString())
+              .name("temp.pdf")
+              .originalSize(1024L)
+              .mimeType("application/pdf")
+              .type(FileMetadataType.ATTACHMENT)
+              .userId(user1Id.toString())
+              .roomId(roomId.toString());
+      FileMetadata fileMetadata = metadataBuilder.build();
+      when(fileMetadataRepository.getById(originalAttachmentId.toString()))
+          .thenReturn(Optional.of(fileMetadata));
+      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
+      UUID attachmentUuid = UUID.randomUUID();
+      try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
+        uuid.when(UUID::randomUUID).thenReturn(attachmentUuid);
+        uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
+        uuid.when(() -> UUID.fromString(roomId.toString())).thenReturn(roomId);
+        attachmentService.copyAttachment(room1, originalAttachmentId, currentUser);
+      }
+
+      verify(fileMetadataRepository, times(1)).getById(originalAttachmentId.toString());
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(storagesService, times(1))
+          .copyFile(
+              originalAttachmentId.toString(),
+              user1Id.toString(),
+              attachmentUuid.toString(),
+              user1Id.toString());
+      ArgumentCaptor<FileMetadata> fileMetadataArgumentCaptor =
+          ArgumentCaptor.forClass(FileMetadata.class);
+      verify(fileMetadataRepository, times(1)).save(fileMetadataArgumentCaptor.capture());
+      FileMetadata copiedFileMetadata = fileMetadataArgumentCaptor.getValue();
+      assertEquals(attachmentUuid.toString(), copiedFileMetadata.getId());
+      assertEquals("temp.pdf", copiedFileMetadata.getName());
+      assertEquals(1024L, copiedFileMetadata.getOriginalSize());
+      assertEquals("application/pdf", copiedFileMetadata.getMimeType());
+      assertEquals(FileMetadataType.ATTACHMENT, copiedFileMetadata.getType());
+      assertEquals(user1Id.toString(), copiedFileMetadata.getUserId());
+      assertEquals(roomId.toString(), copiedFileMetadata.getRoomId());
+      verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
+    }
+
+    @Test
+    @DisplayName("Re throws an exception if the room is not found")
+    void copyAttachment_testErrorRoomNotFound() {
+      UserPrincipal currentUser = UserPrincipal.create(user1Id);
+      UUID originalAttachmentId = UUID.randomUUID();
+      FileMetadataBuilder metadataBuilder =
+          FileMetadataBuilder.create()
+              .id(originalAttachmentId.toString())
+              .name("temp.pdf")
+              .originalSize(1024L)
+              .mimeType("application/pdf")
+              .type(FileMetadataType.ATTACHMENT)
+              .userId(user1Id.toString())
+              .roomId(roomId.toString());
+      FileMetadata fileMetadata = metadataBuilder.build();
+      when(fileMetadataRepository.getById(originalAttachmentId.toString()))
+          .thenReturn(Optional.of(fileMetadata));
+      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+          .thenThrow(NotFoundException.class);
+      try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
+        uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
+        uuid.when(() -> UUID.fromString(roomId.toString())).thenReturn(roomId);
+
+        assertThrows(
+            NotFoundException.class,
+            () -> attachmentService.copyAttachment(room1, originalAttachmentId, currentUser));
+      }
+
+      verify(fileMetadataRepository, times(1)).getById(originalAttachmentId.toString());
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
+    }
+
+    @Test
+    @DisplayName("Re throws an exception if the member is not part of the room")
+    void copyAttachment_testErrorForbiddenException() {
+      UserPrincipal currentUser = UserPrincipal.create(user1Id);
+      UUID originalAttachmentId = UUID.randomUUID();
+      FileMetadataBuilder metadataBuilder =
+          FileMetadataBuilder.create()
+              .id(originalAttachmentId.toString())
+              .name("temp.pdf")
+              .originalSize(1024L)
+              .mimeType("application/pdf")
+              .type(FileMetadataType.ATTACHMENT)
+              .userId(user1Id.toString())
+              .roomId(roomId.toString());
+      FileMetadata fileMetadata = metadataBuilder.build();
+      when(fileMetadataRepository.getById(originalAttachmentId.toString()))
+          .thenReturn(Optional.of(fileMetadata));
+      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+          .thenThrow(ForbiddenException.class);
+      try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
+        uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
+        uuid.when(() -> UUID.fromString(roomId.toString())).thenReturn(roomId);
+
+        assertThrows(
+            ForbiddenException.class,
+            () -> attachmentService.copyAttachment(room1, originalAttachmentId, currentUser));
+      }
+
+      verify(fileMetadataRepository, times(1)).getById(originalAttachmentId.toString());
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
+    }
+
+    @Test
+    @DisplayName("Re throws an exception if storage service fails")
+    void copyAttachment_testErrorStorageException() {
+      UserPrincipal currentUser = UserPrincipal.create(user1Id);
+      UUID originalAttachmentId = UUID.randomUUID();
+      FileMetadataBuilder metadataBuilder =
+          FileMetadataBuilder.create()
+              .id(originalAttachmentId.toString())
+              .name("temp.pdf")
+              .originalSize(1024L)
+              .mimeType("application/pdf")
+              .type(FileMetadataType.ATTACHMENT)
+              .userId(user1Id.toString())
+              .roomId(roomId.toString());
+      FileMetadata fileMetadata = metadataBuilder.build();
+      when(fileMetadataRepository.getById(originalAttachmentId.toString()))
+          .thenReturn(Optional.of(fileMetadata));
+      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
+      UUID attachmentUuid = UUID.randomUUID();
+      doThrow(StorageException.class)
+          .when(storagesService)
+          .copyFile(
+              originalAttachmentId.toString(),
+              user1Id.toString(),
+              attachmentUuid.toString(),
+              user1Id.toString());
+      try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
+        uuid.when(UUID::randomUUID).thenReturn(attachmentUuid);
+        uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
+        uuid.when(() -> UUID.fromString(roomId.toString())).thenReturn(roomId);
+
+        assertThrows(
+            StorageException.class,
+            () -> attachmentService.copyAttachment(room1, originalAttachmentId, currentUser));
+      }
+
+      verify(fileMetadataRepository, times(1)).getById(originalAttachmentId.toString());
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(storagesService, times(1))
+          .copyFile(
+              originalAttachmentId.toString(),
+              user1Id.toString(),
+              attachmentUuid.toString(),
+              user1Id.toString());
+      verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
     }
   }
 
@@ -734,11 +918,11 @@ public class AttachmentServiceImplTest {
 
       attachmentService.deleteAttachment(attachmentUuid, currentUser);
 
-      verify(fileMetadataRepository, times(1)).delete(expectedMetadata);
       verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
-      verifyNoMoreInteractions(fileMetadataRepository);
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
       verify(storagesService, times(1)).deleteFile(attachmentUuid.toString(), user2Id.toString());
-      verifyNoMoreInteractions(storagesService);
+      verify(fileMetadataRepository, times(1)).delete(expectedMetadata);
+      verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
     }
 
     @Test
@@ -761,11 +945,11 @@ public class AttachmentServiceImplTest {
 
       attachmentService.deleteAttachment(attachmentUuid, currentUser);
 
-      verify(fileMetadataRepository, times(1)).delete(expectedMetadata);
       verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
-      verifyNoMoreInteractions(fileMetadataRepository);
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
       verify(storagesService, times(1)).deleteFile(attachmentUuid.toString(), user2Id.toString());
-      verifyNoMoreInteractions(storagesService);
+      verify(fileMetadataRepository, times(1)).delete(expectedMetadata);
+      verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
     }
 
     @Test
@@ -775,13 +959,12 @@ public class AttachmentServiceImplTest {
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
       when(fileMetadataRepository.getById(attachmentUuid.toString())).thenReturn(Optional.empty());
 
-      NotFoundException notFoundException =
-          assertThrows(
-              NotFoundException.class,
-              () -> attachmentService.deleteAttachment(attachmentUuid, currentUser));
-      assertEquals(
-          String.format("Not Found - File with id '%s' not found", attachmentUuid),
-          notFoundException.getMessage());
+      assertThrows(
+          NotFoundException.class,
+          () -> attachmentService.deleteAttachment(attachmentUuid, currentUser));
+
+      verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
+      verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
     }
 
     @Test
@@ -803,11 +986,13 @@ public class AttachmentServiceImplTest {
       when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
           .thenThrow(new NotFoundException());
 
-      NotFoundException notFoundException =
-          assertThrows(
-              NotFoundException.class,
-              () -> attachmentService.deleteAttachment(attachmentUuid, currentUser));
-      assertEquals("Not Found - Not Found", notFoundException.getMessage());
+      assertThrows(
+          NotFoundException.class,
+          () -> attachmentService.deleteAttachment(attachmentUuid, currentUser));
+
+      verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
     }
 
     @Test
@@ -827,13 +1012,18 @@ public class AttachmentServiceImplTest {
       when(fileMetadataRepository.getById(attachmentUuid.toString()))
           .thenReturn(Optional.of(expectedMetadata));
       when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
-      doThrow(new InternalErrorException())
+      doThrow(new StorageException())
           .when(storagesService)
           .deleteFile(attachmentUuid.toString(), user2Id.toString());
 
       assertThrows(
-          InternalErrorException.class,
+          StorageException.class,
           () -> attachmentService.deleteAttachment(attachmentUuid, currentUser));
+
+      verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
+      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(storagesService, times(1)).deleteFile(attachmentUuid.toString(), user2Id.toString());
+      verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
     }
 
     @Test
@@ -879,10 +1069,10 @@ public class AttachmentServiceImplTest {
 
       attachmentService.deleteAttachmentsByRoomId(roomId, UserPrincipal.create(user1Id));
 
-      verify(storagesService, times(1))
-          .deleteFileList(List.of(file1Id, file2Id), user1Id.toString());
       verify(fileMetadataRepository, times(1))
           .getIdsByRoomIdAndType(roomId.toString(), FileMetadataType.ATTACHMENT);
+      verify(storagesService, times(1))
+          .deleteFileList(List.of(file1Id, file2Id), user1Id.toString());
       verify(fileMetadataRepository, times(1)).deleteByIds(List.of(file1Id, file2Id));
       verifyNoMoreInteractions(storagesService, fileMetadataRepository);
     }
@@ -901,10 +1091,10 @@ public class AttachmentServiceImplTest {
 
       attachmentService.deleteAttachmentsByRoomId(roomId, UserPrincipal.create(user1Id));
 
-      verify(storagesService, times(1))
-          .deleteFileList(List.of(file1Id, file2Id), user1Id.toString());
       verify(fileMetadataRepository, times(1))
           .getIdsByRoomIdAndType(roomId.toString(), FileMetadataType.ATTACHMENT);
+      verify(storagesService, times(1))
+          .deleteFileList(List.of(file1Id, file2Id), user1Id.toString());
       verify(fileMetadataRepository, times(1)).deleteByIds(List.of(file1Id));
       verifyNoMoreInteractions(storagesService, fileMetadataRepository);
     }
@@ -923,10 +1113,10 @@ public class AttachmentServiceImplTest {
 
       attachmentService.deleteAttachmentsByRoomId(roomId, UserPrincipal.create(user1Id));
 
-      verify(storagesService, times(1))
-          .deleteFileList(List.of(file1Id, file2Id), user1Id.toString());
       verify(fileMetadataRepository, times(1))
           .getIdsByRoomIdAndType(roomId.toString(), FileMetadataType.ATTACHMENT);
+      verify(storagesService, times(1))
+          .deleteFileList(List.of(file1Id, file2Id), user1Id.toString());
       verifyNoMoreInteractions(storagesService, fileMetadataRepository);
     }
   }

--- a/carbonio-ws-collaboration-core/src/test/resources/build-information
+++ b/carbonio-ws-collaboration-core/src/test/resources/build-information
@@ -1,1 +1,1 @@
-ws-collaboration.version=0.6.0
+ws-collaboration.version=0.7.1

--- a/carbonio-ws-collaboration-it/pom.xml
+++ b/carbonio-ws-collaboration-it/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.ws-collaboration</groupId>
     <artifactId>carbonio-ws-collaboration-ce</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.1</version>
   </parent>
 
   <artifactId>carbonio-ws-collaboration-ce-it</artifactId>

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/AttachmentsApiIT.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/AttachmentsApiIT.java
@@ -225,16 +225,6 @@ public class AttachmentsApiIT {
     }
 
     @Test
-    @DisplayName("Returns 424 if the Storage server is down")
-    void getAttachment_testExceptionStorageServerKO() throws Exception {
-      storageMockServer.setIsAliveResponse(false);
-
-      MockHttpResponse response = dispatcher.get(url(UUID.randomUUID().toString()), null);
-
-      assertEquals(424, response.getStatus());
-    }
-
-    @Test
     @DisplayName(
         "Given an attachment identifier, if the user is not authenticated return a status code 401")
     void getAttachment_testErrorUnauthenticatedUser() throws Exception {

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/tools/StorageMockServer.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/tools/StorageMockServer.java
@@ -18,7 +18,6 @@ import com.zextras.storages.internal.pojo.StoragesBulkDeleteResponse;
 import com.zextras.storages.internal.pojo.StoragesUploadResponse;
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.ClearType;
@@ -98,7 +97,7 @@ public class StorageMockServer extends ClientAndServer implements CloseableResou
                   item.setNode(fileId);
                   return item;
                 })
-            .collect(Collectors.toList()));
+            .toList());
     return request()
         .withMethod("POST")
         .withPath("/bulk-delete")
@@ -120,7 +119,7 @@ public class StorageMockServer extends ClientAndServer implements CloseableResou
                     query.setNode(fileId);
                     return query;
                   })
-              .collect(Collectors.toList()));
+              .toList());
       when(request).respond(response().withStatusCode(200).withBody(JsonBody.json(responseBody)));
     } else {
       when(request).respond(response().withStatusCode(500));

--- a/carbonio-ws-collaboration-it/src/test/resources/build-information
+++ b/carbonio-ws-collaboration-it/src/test/resources/build-information
@@ -1,1 +1,1 @@
-ws-collaboration.version=0.6.0
+ws-collaboration.version=0.7.1

--- a/carbonio-ws-collaboration-openapi/pom.xml
+++ b/carbonio-ws-collaboration-openapi/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.ws-collaboration</groupId>
     <artifactId>carbonio-ws-collaboration-ce</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.1</version>
   </parent>
 
   <artifactId>carbonio-ws-collaboration-ce-openapi</artifactId>

--- a/carbonio-ws-collaboration-openapi/src/main/resources/chats/chats-api.yaml
+++ b/carbonio-ws-collaboration-openapi/src/main/resources/chats/chats-api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.3
 info:
   title: Zextras Workstream Collaboration CE Chats Api
   description: Zextras Carbonio Workstream Collaboration CE Chats HTTP APIs definition.
-  version: 0.6.0
+  version: 0.7.1
   contact:
     email: smokybeans@zextras.com
 servers:

--- a/carbonio-ws-collaboration-openapi/src/main/resources/meeting/meeting-api.yaml
+++ b/carbonio-ws-collaboration-openapi/src/main/resources/meeting/meeting-api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.3
 info:
   title: Zextras Carbonio Workstream Collaboration CE Meeting Api
   description: Zextras Carbonio Workstream Collaboration CE Meeting HTTP APIs definition.
-  version: 0.6.0
+  version: 0.7.1
   contact:
     email: smokybeans@zextras.com
 servers:

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname="carbonio-ws-collaboration-ce"
 pkgver="0.7.1"
-pkgrel="1"
+pkgrel="2"
 pkgdesc="Workstream Collaboration for Carbonio CE"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-ws-collaboration-ce"
-pkgver="0.6.0"
+pkgver="0.7.1"
 pkgrel="1"
 pkgdesc="Workstream Collaboration for Carbonio CE"
 maintainer="Zextras <packages@zextras.com>"
@@ -41,7 +41,7 @@ sha256sums=('7233d077c9cda00b53f482c30cc86af8ca37362f43f6c7f164d7d28c73447c3e'
   'a993f63dbfa8273d92f004c6db2886f17d9876d36c65ab757456ab99c0a3f3c3'
   '58c69efd45348762b3c603ecb8a7d3df5e4ada730b00a760d02d3f376a455d08'
   '7dbc2225d51fb07c1e3e5577f8ba80d8cd9634c7c47f5b0ab1edbc949d97ff21'
-  'd3741e4103a786c40a319248258ee5a25a39174a6ba80973b5877bb8a5e2bf72')
+  'ef55ad102e9a356478233654a104fb84534170c30f765371cd91fb32c3be3578')
 
 package() {
   cd "${srcdir}"/../../ws-collaboration

--- a/package/service-protocol.json
+++ b/package/service-protocol.json
@@ -1,6 +1,5 @@
 {
   "Kind": "service-defaults",
   "Name": "carbonio-ws-collaboration",
-  "Protocol": "http",
-  "Websocket": true
+  "Protocol": "http"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.ws-collaboration</groupId>
   <artifactId>carbonio-ws-collaboration-ce</artifactId>
-  <version>0.6.0</version>
+  <version>0.7.1</version>
 
   <repositories>
     <repository>


### PR DESCRIPTION
* chore: align with main branch
* chore: save metadata of files in the FileMetadata table only after storages service operations succeeded
* chore: make dependency check optional in Jenkinsfile
* chore: bump package version to 0.7.1-2

ref: WSC-1707

---------

Co-authored-by: Federico Rispo <federico.rispo@zextras.com>
Co-authored-by: Matteo Baglini <matteo.baglini@gmail.com>