### PR TITLE
chore!: update insert room and add member APIs

### DIFF
--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/MessageDispatcher.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/MessageDispatcher.java
@@ -5,10 +5,10 @@
 package com.zextras.carbonio.chats.core.infrastructure.messaging;
 
 import com.zextras.carbonio.chats.core.data.entity.FileMetadata;
-import com.zextras.carbonio.chats.core.data.entity.Room;
 import com.zextras.carbonio.chats.core.infrastructure.HealthIndicator;
 import com.zextras.carbonio.chats.model.ForwardMessageDto;
 import jakarta.annotation.Nullable;
+import java.util.List;
 import java.util.Optional;
 
 public interface MessageDispatcher extends HealthIndicator {
@@ -16,10 +16,11 @@ public interface MessageDispatcher extends HealthIndicator {
   /**
    * Creates a room on XMPP server
    *
-   * @param room room entity to save
+   * @param roomId identifier of the room to create
    * @param senderId creation user
+   * @param memberIds identifiers of the members invited in this room
    */
-  void createRoom(Room room, String senderId);
+  void createRoom(String roomId, String senderId, List<String> memberIds);
 
   /**
    * Deletes a room on XMPP server

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/MessageDispatcher.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/MessageDispatcher.java
@@ -80,9 +80,9 @@ public interface MessageDispatcher extends HealthIndicator {
    *
    * @param roomId room identifier
    * @param senderId operation user identifier
-   * @param idToRemove identifier of the user to remove
+   * @param userIdToRemove identifier of the user to remove
    */
-  void removeRoomMember(String roomId, String senderId, String idToRemove);
+  void removeRoomMember(String roomId, String senderId, String userIdToRemove);
 
   /**
    * Sets two users in their respective contacts list so that they can both see each other's

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/MessageDispatcherMongooseImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/MessageDispatcherMongooseImpl.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zextras.carbonio.chats.core.data.entity.FileMetadata;
-import com.zextras.carbonio.chats.core.data.entity.Room;
 import com.zextras.carbonio.chats.core.exception.MessageDispatcherException;
 import com.zextras.carbonio.chats.core.infrastructure.messaging.MessageDispatcher;
 import com.zextras.carbonio.chats.core.infrastructure.messaging.MessageType;
@@ -66,11 +65,11 @@ public class MessageDispatcherMongooseImpl implements MessageDispatcher {
   }
 
   @Override
-  public void createRoom(Room room, String senderId) {
+  public void createRoom(String roomId, String senderId, List<String> memberIds) {
     String query =
         "mutation muc_light { muc_light { createRoom ("
             + String.format("mucDomain: \"%s\", ", MUC_DOMAIN)
-            + String.format("id: \"%s\", ", room.getId())
+            + String.format("id: \"%s\", ", roomId)
             + String.format("owner: \"%s\"", userIdToUserDomain(senderId))
             + ") { jid } } }";
     GraphQlResponse result = executeMutation(GraphQlBody.create(query, MUC_LIGHT, Map.of()));
@@ -85,9 +84,7 @@ public class MessageDispatcherMongooseImpl implements MessageDispatcher {
         throw new MessageDispatcherException(PARSING_ERROR, e);
       }
     }
-    room.getSubscriptions().stream()
-        .filter(member -> !member.getUserId().equals(senderId))
-        .forEach(member -> addRoomMember(room.getId(), senderId, member.getUserId()));
+    memberIds.forEach(member -> addRoomMember(roomId, senderId, member));
   }
 
   @Override

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/MessageDispatcherMongooseImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/MessageDispatcherMongooseImpl.java
@@ -216,13 +216,13 @@ public class MessageDispatcherMongooseImpl implements MessageDispatcher {
   }
 
   @Override
-  public void removeRoomMember(String roomId, String senderId, String idToRemove) {
+  public void removeRoomMember(String roomId, String senderId, String userIdToRemove) {
     GraphQlResponse result =
         executeMutation(
             GraphQlBody.create(
                 "mutation muc_light { muc_light { kickUser ("
                     + String.format("room: \"%s\", ", roomIdToRoomDomain(roomId))
-                    + String.format("user: \"%s\") ", userIdToUserDomain(idToRemove))
+                    + String.format("user: \"%s\") ", userIdToUserDomain(userIdToRemove))
                     + "} }",
                 MUC_LIGHT,
                 Map.of()));
@@ -236,7 +236,7 @@ public class MessageDispatcherMongooseImpl implements MessageDispatcher {
         throw new MessageDispatcherException(PARSING_ERROR, e);
       }
     }
-    sendAffiliationMessage(roomId, senderId, idToRemove, false);
+    sendAffiliationMessage(roomId, senderId, userIdToRemove, false);
   }
 
   private void sendAffiliationMessage(

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/mapper/SubscriptionMapper.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/mapper/SubscriptionMapper.java
@@ -4,10 +4,8 @@
 
 package com.zextras.carbonio.chats.core.mapper;
 
-import com.zextras.carbonio.chats.core.data.entity.RoomUserSettings;
 import com.zextras.carbonio.chats.core.data.entity.Subscription;
 import com.zextras.carbonio.chats.model.MemberDto;
-import com.zextras.carbonio.chats.model.MemberInsertedDto;
 import jakarta.annotation.Nullable;
 import java.util.List;
 
@@ -29,15 +27,4 @@ public interface SubscriptionMapper {
    * @return conversation result ({@link List} of {@link MemberDto})
    */
   List<MemberDto> ent2memberDto(@Nullable List<Subscription> subscriptions);
-
-  /**
-   * Converts {@link Subscription} to {@link MemberInsertedDto} with current user settings
-   *
-   * @param subscription {@link Subscription} to convert
-   * @param roomUserSettings current user settings {@link RoomUserSettings}
-   * @return conversation result {@link MemberInsertedDto}
-   */
-  @Nullable
-  MemberInsertedDto ent2memberInsertedDto(
-      @Nullable Subscription subscription, @Nullable RoomUserSettings roomUserSettings);
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/mapper/impl/SubscriptionMapperImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/mapper/impl/SubscriptionMapperImpl.java
@@ -5,11 +5,9 @@
 package com.zextras.carbonio.chats.core.mapper.impl;
 
 import com.google.inject.Singleton;
-import com.zextras.carbonio.chats.core.data.entity.RoomUserSettings;
 import com.zextras.carbonio.chats.core.data.entity.Subscription;
 import com.zextras.carbonio.chats.core.mapper.SubscriptionMapper;
 import com.zextras.carbonio.chats.model.MemberDto;
-import com.zextras.carbonio.chats.model.MemberInsertedDto;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.UUID;
@@ -33,18 +31,5 @@ public class SubscriptionMapperImpl implements SubscriptionMapper {
     return subscriptions == null
         ? List.of()
         : subscriptions.stream().map(this::ent2memberDto).toList();
-  }
-
-  @Override
-  @Nullable
-  public MemberInsertedDto ent2memberInsertedDto(
-      @Nullable Subscription subscription, @Nullable RoomUserSettings roomUserSettings) {
-    if (subscription == null) {
-      return null;
-    }
-    return MemberInsertedDto.create()
-        .owner(subscription.isOwner())
-        .userId(UUID.fromString(subscription.getUserId()))
-        .clearedAt(roomUserSettings == null ? null : roomUserSettings.getClearedAt());
   }
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/repository/FileMetadataRepository.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/repository/FileMetadataRepository.java
@@ -71,13 +71,6 @@ public interface FileMetadataRepository {
   void delete(FileMetadata metadata);
 
   /**
-   * Deletes metadata info by its identifier
-   *
-   * @param id identifier of metadata to delete
-   */
-  void deleteById(String id);
-
-  /**
    * Delete a metadata info list by their identifier
    *
    * @param ids identifier of metadata info to delete

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/repository/impl/EbeanFileMetadataRepository.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/repository/impl/EbeanFileMetadataRepository.java
@@ -92,11 +92,6 @@ public class EbeanFileMetadataRepository implements FileMetadataRepository {
   }
 
   @Override
-  public void deleteById(String id) {
-    db.delete(FileMetadata.class, id);
-  }
-
-  @Override
   public void deleteByIds(List<String> ids) {
     if (!ids.isEmpty()) {
       db.deleteAll(FileMetadata.class, ids);

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/MembersService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/MembersService.java
@@ -17,20 +17,20 @@ import java.util.UUID;
 public interface MembersService {
 
   /**
-   * Gets the member data of the requested room by user identifier
+   * Gets the subscription data of the requested room by user identifier
    *
    * @param userId user identifier {@link UUID}
    * @param roomId room identifier{@link UUID}
-   * @return a {@link MemberDto} wrapped in an {@link Optional}
+   * @return a {@link Subscription} wrapped in an {@link Optional}
    */
-  Optional<MemberDto> getByUserIdAndRoomId(UUID userId, UUID roomId);
+  Optional<Subscription> getSubscription(UUID userId, UUID roomId);
 
   /**
    * Sets a user as room owner
    *
-   * @param roomId      room identifier {@link UUID}
-   * @param userId      identifier of the user to set as owner {@link UUID}
-   * @param isOwner     if true the user will be set as owner otherwise as a simple member
+   * @param roomId room identifier {@link UUID}
+   * @param userId identifier of the user to set as owner {@link UUID}
+   * @param isOwner if true the user will be set as owner otherwise as a simple member
    * @param currentUser current authenticated user {@link UserPrincipal}
    */
   void setOwner(UUID roomId, UUID userId, boolean isOwner, UserPrincipal currentUser);
@@ -38,32 +38,39 @@ public interface MembersService {
   /**
    * Adds the specified user to the room. This can only be performed by an of the given room
    *
-   * @param roomId            room identifier {@link UUID }
+   * @param roomId room identifier {@link UUID }
    * @param memberToInsertDto member to add or invite {@link MemberDto }
-   * @param currentUser       current authenticated user {@link UserPrincipal}
+   * @param currentUser current authenticated user {@link UserPrincipal}
    * @return The member added or invited {@link MemberDto }
-   **/
-  MemberInsertedDto insertRoomMember(UUID roomId, MemberToInsertDto memberToInsertDto, UserPrincipal currentUser);
+   */
+  MemberInsertedDto insertRoomMember(
+      UUID roomId, MemberToInsertDto memberToInsertDto, UserPrincipal currentUser);
 
   /**
-   * Removes a member from the specified room. If the specified user is different from the requester, this action is
-   * considered as a kick
+   * Removes a member from the specified room. If the specified user is different from the
+   * requester, this action is considered as a kick
    *
-   * @param roomId      room identifier {@link UUID }
-   * @param userId      user identifier {@link UUID }
+   * @param roomId room identifier {@link UUID }
+   * @param userId user identifier {@link UUID }
    * @param currentUser current authenticated user {@link UserPrincipal}
-   **/
+   */
   void deleteRoomMember(UUID roomId, UUID userId, UserPrincipal currentUser);
 
   /**
    * Retrieves every member to the given room
    *
-   * @param roomId      room identifier {@link UUID }
+   * @param roomId room identifier {@link UUID }
    * @param currentUser current authenticated user {@link UserPrincipal}
    * @return The room members list {@link MemberDto }
-   **/
+   */
   List<MemberDto> getRoomMembers(UUID roomId, UserPrincipal currentUser);
 
-  List<Subscription> initRoomSubscriptions(List<UUID> membersIds, Room room, UserPrincipal requester);
-
+  /**
+   * Add every member into the specified room
+   *
+   * @param members {@link List} of member to add
+   * @param room {@link Room} where to add the members to
+   * @return {@link List} of {@link Subscription} added
+   */
+  List<Subscription> initRoomSubscriptions(List<MemberDto> members, Room room);
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/MembersService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/MembersService.java
@@ -36,15 +36,15 @@ public interface MembersService {
   void setOwner(UUID roomId, UUID userId, boolean isOwner, UserPrincipal currentUser);
 
   /**
-   * Adds the specified user to the room. This can only be performed by an of the given room
+   * Add the specified users to the room. This can only be performed by an of the given room
    *
    * @param roomId room identifier {@link UUID }
-   * @param memberToInsertDto member to add or invite {@link MemberDto }
+   * @param memberToInsertDto members to add or invite {@link MemberDto }
    * @param currentUser current authenticated user {@link UserPrincipal}
    * @return The member added or invited {@link MemberDto }
    */
-  MemberInsertedDto insertRoomMember(
-      UUID roomId, MemberToInsertDto memberToInsertDto, UserPrincipal currentUser);
+  List<MemberInsertedDto> insertRoomMembers(
+      UUID roomId, List<MemberToInsertDto> memberToInsertDto, UserPrincipal currentUser);
 
   /**
    * Removes a member from the specified room. If the specified user is different from the

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/RoomService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/RoomService.java
@@ -45,7 +45,7 @@ public interface RoomService {
    * @throws ForbiddenException if the user isn't a room member
    * @throws ForbiddenException if the user isn't a room owner and mustBeOwner is true
    */
-  Room getRoomEntityAndCheckUser(UUID roomId, UserPrincipal currentUser, boolean mustBeOwner);
+  Room getRoomAndValidateUser(UUID roomId, UserPrincipal currentUser, boolean mustBeOwner);
 
   /**
    * Gets the room entity for internal usage

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/UserService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/UserService.java
@@ -16,26 +16,27 @@ public interface UserService {
   /**
    * Retrieves info about a user
    *
-   * @param userId      the requested user's {@link UUID}
+   * @param userId the requested user's {@link UUID}
    * @param currentUser the currently authenticated {@link UserPrincipal}
    * @return the requested {@link UserDto}
-   **/
+   */
   UserDto getUserById(UUID userId, UserPrincipal currentUser);
 
   /**
    * Retrieves info about a list of user
    *
-   * @param userIds     list of the requested users' {@link UUID}
+   * @param userIds list of the requested users' {@link UUID}
    * @param currentUser the currently authenticated {@link UserPrincipal}
    * @return the {@link List} of the requested {@link UserDto}
-   **/
+   */
   List<UserDto> getUsersByIds(List<String> userIds, UserPrincipal currentUser);
 
   /**
-   * Checks if a user exists. Current implementations checks the {@link com.zextras.carbonio.chats.core.infrastructure.profiling.ProfilingService}
-   * to check if the user exists.
+   * Checks if a user exists. Current implementations checks the {@link
+   * com.zextras.carbonio.chats.core.infrastructure.profiling.ProfilingService} to check if the user
+   * exists.
    *
-   * @param userId      the user whose existance we need to check
+   * @param userId the user whose existence we need to check
    * @param currentUser the current authenticated user
    * @return a {@link Boolean} which indicates if the user exists or not
    */
@@ -44,7 +45,7 @@ public interface UserService {
   /**
    * Gets the user picture
    *
-   * @param userId      user identifier
+   * @param userId user identifier
    * @param currentUser current authenticated user {@link UserPrincipal}
    * @return The user picture
    */
@@ -53,19 +54,25 @@ public interface UserService {
   /**
    * Sets a new user picture
    *
-   * @param userId        room identifier {@link UUID }
-   * @param image         image stream to set {@link InputStream}
-   * @param mimeType      image mime type
+   * @param userId room identifier {@link UUID }
+   * @param image image stream to set {@link InputStream}
+   * @param mimeType image mime type
    * @param contentLength image size
-   * @param fileName      image file name
-   * @param currentUser   current authenticated user {@link UserPrincipal}
-   **/
-  void setUserPicture(UUID userId, InputStream image, String mimeType, Long contentLength, String fileName, UserPrincipal currentUser);
+   * @param fileName image file name
+   * @param currentUser current authenticated user {@link UserPrincipal}
+   */
+  void setUserPicture(
+      UUID userId,
+      InputStream image,
+      String mimeType,
+      Long contentLength,
+      String fileName,
+      UserPrincipal currentUser);
 
   /**
    * Deletes the user picture
    *
-   * @param userId      room identifier {@link UUID }
+   * @param userId room identifier {@link UUID }
    * @param currentUser current authenticated user {@link UserPrincipal}
    */
   void deleteUserPicture(UUID userId, UserPrincipal currentUser);

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/AttachmentServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/AttachmentServiceImpl.java
@@ -73,8 +73,7 @@ public class AttachmentServiceImpl implements AttachmentService {
             .getById(fileId.toString())
             .orElseThrow(
                 () -> new NotFoundException(String.format("Attachment '%s' not found", fileId)));
-    roomService.getRoomEntityAndCheckUser(
-        UUID.fromString(metadata.getRoomId()), currentUser, false);
+    roomService.getRoomAndValidateUser(UUID.fromString(metadata.getRoomId()), currentUser, false);
     return new FileContentAndMetadata(
         storagesService.getFileStreamById(metadata.getId(), metadata.getUserId()), metadata);
   }
@@ -82,7 +81,7 @@ public class AttachmentServiceImpl implements AttachmentService {
   @Override
   public AttachmentsPaginationDto getAttachmentInfoByRoomId(
       UUID roomId, Integer itemsNumber, @Nullable String filter, UserPrincipal currentUser) {
-    roomService.getRoomEntityAndCheckUser(roomId, currentUser, false);
+    roomService.getRoomAndValidateUser(roomId, currentUser, false);
     PaginationFilter paginationFilter = null;
     if (filter != null) {
       try {
@@ -126,8 +125,7 @@ public class AttachmentServiceImpl implements AttachmentService {
             .getById(fileId.toString())
             .orElseThrow(
                 () -> new NotFoundException(String.format("Attachment '%s' not found", fileId)));
-    roomService.getRoomEntityAndCheckUser(
-        UUID.fromString(metadata.getRoomId()), currentUser, false);
+    roomService.getRoomAndValidateUser(UUID.fromString(metadata.getRoomId()), currentUser, false);
     return attachmentMapper.ent2dto(metadata);
   }
 
@@ -143,7 +141,7 @@ public class AttachmentServiceImpl implements AttachmentService {
       @Nullable String replyId,
       @Nullable String area,
       UserPrincipal currentUser) {
-    roomService.getRoomEntityAndCheckUser(roomId, currentUser, false);
+    roomService.getRoomAndValidateUser(roomId, currentUser, false);
     UUID fileId = UUID.randomUUID();
     FileMetadata metadata =
         FileMetadata.create()
@@ -180,7 +178,7 @@ public class AttachmentServiceImpl implements AttachmentService {
                 () ->
                     new NotFoundException(
                         String.format("Attachment '%s' not found", originalAttachmentId)));
-    roomService.getRoomEntityAndCheckUser(
+    roomService.getRoomAndValidateUser(
         UUID.fromString(sourceMetadata.getRoomId()), currentUser, false);
     FileMetadata metadata =
         FileMetadata.create()
@@ -205,7 +203,7 @@ public class AttachmentServiceImpl implements AttachmentService {
             .orElseThrow(
                 () -> new NotFoundException(String.format("Attachment '%s' not found", fileId)));
     Room room =
-        roomService.getRoomEntityAndCheckUser(
+        roomService.getRoomAndValidateUser(
             UUID.fromString(metadata.getRoomId()), currentUser, false);
     room.getSubscriptions().stream()
         .filter(

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/MeetingServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/MeetingServiceImpl.java
@@ -72,7 +72,7 @@ public class MeetingServiceImpl implements MeetingService {
       UUID roomId,
       OffsetDateTime expiration) {
     return meetingMapper.ent2dto(
-        Option.of(roomService.getRoomEntityAndCheckUser(roomId, user, false))
+        Option.of(roomService.getRoomAndValidateUser(roomId, user, false))
             .map(
                 room -> {
                   if (room.getMeetingId() == null) {
@@ -185,7 +185,7 @@ public class MeetingServiceImpl implements MeetingService {
 
   @Override
   public MeetingDto getMeetingByRoomId(UUID roomId, UserPrincipal currentUser) {
-    roomService.getRoomEntityAndCheckUser(roomId, currentUser, false);
+    roomService.getRoomAndValidateUser(roomId, currentUser, false);
     return meetingMapper.ent2dto(
         getMeetingEntityByRoomId(roomId)
             .orElseThrow(
@@ -206,7 +206,7 @@ public class MeetingServiceImpl implements MeetingService {
 
     deleteMeeting(
         meeting,
-        roomService.getRoomEntityAndCheckUser(
+        roomService.getRoomAndValidateUser(
             UUID.fromString(meeting.getRoomId()), currentUser, false),
         currentUser.getUUID());
   }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/MeetingServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/MeetingServiceImpl.java
@@ -163,7 +163,7 @@ public class MeetingServiceImpl implements MeetingService {
                     new NotFoundException(
                         String.format("Meeting with id '%s' not found", meetingId)));
     if (membersService
-        .getByUserIdAndRoomId(currentUser.getUUID(), UUID.fromString(meeting.getRoomId()))
+        .getSubscription(currentUser.getUUID(), UUID.fromString(meeting.getRoomId()))
         .isEmpty()) {
       throw new ForbiddenException(
           String.format(

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImpl.java
@@ -78,10 +78,8 @@ public class MembersServiceImpl implements MembersService {
   }
 
   @Override
-  public Optional<MemberDto> getByUserIdAndRoomId(UUID userId, UUID roomId) {
-    return Optional.ofNullable(
-        subscriptionMapper.ent2memberDto(
-            subscriptionRepository.getById(roomId.toString(), userId.toString()).orElse(null)));
+  public Optional<Subscription> getSubscription(UUID userId, UUID roomId) {
+    return subscriptionRepository.getById(roomId.toString(), userId.toString());
   }
 
   @Override
@@ -220,19 +218,16 @@ public class MembersServiceImpl implements MembersService {
   }
 
   @Override
-  public List<Subscription> initRoomSubscriptions(
-      List<UUID> membersIds, Room room, UserPrincipal requester) {
-    return membersIds.stream()
+  public List<Subscription> initRoomSubscriptions(List<MemberDto> members, Room room) {
+    return members.stream()
         .map(
-            userId ->
+            member ->
                 Subscription.create()
-                    .id(new SubscriptionId(room.getId(), userId.toString()))
-                    .userId(userId.toString())
+                    .id(new SubscriptionId(room.getId(), member.getUserId().toString()))
+                    .userId(member.getUserId().toString())
                     .room(room)
                     // When we have a one to one, both members are owners
-                    .owner(
-                        userId.equals(requester.getUUID())
-                            || RoomTypeDto.ONE_TO_ONE.equals(room.getType()))
+                    .owner(member.isOwner() || RoomTypeDto.ONE_TO_ONE.equals(room.getType()))
                     .temporary(false)
                     .external(false)
                     .joinedAt(OffsetDateTime.now()))

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImpl.java
@@ -216,7 +216,7 @@ public class ParticipantServiceImpl implements ParticipantService {
     boolean mediaStreamEnabled = mediaStreamSettingsDto.isEnabled();
     switch (mediaStreamSettingsDto.getType()) {
       case VIDEO:
-        if (Boolean.TRUE.equals(participant.hasVideoStreamOn()) != mediaStreamEnabled) {
+        if (participant.hasVideoStreamOn() != mediaStreamEnabled) {
           participantRepository.update(participant.videoStreamOn(mediaStreamEnabled));
           videoServerService.updateMediaStream(
               currentUser.getId(), meetingId.toString(), mediaStreamSettingsDto);
@@ -232,7 +232,7 @@ public class ParticipantServiceImpl implements ParticipantService {
         }
         break;
       case SCREEN:
-        if (Boolean.TRUE.equals(participant.hasScreenStreamOn()) != mediaStreamEnabled) {
+        if (participant.hasScreenStreamOn() != mediaStreamEnabled) {
           participantRepository.update(participant.screenStreamOn(mediaStreamEnabled));
           videoServerService.updateMediaStream(
               currentUser.getId(), meetingId.toString(), mediaStreamSettingsDto);
@@ -283,7 +283,7 @@ public class ParticipantServiceImpl implements ParticipantService {
       roomService.getRoomEntityAndCheckUser(
           UUID.fromString(meeting.getRoomId()), currentUser, true);
     }
-    if (Boolean.TRUE.equals(participant.hasAudioStreamOn()) != enabled) {
+    if (participant.hasAudioStreamOn() != enabled) {
       participantRepository.update(participant.audioStreamOn(enabled));
       videoServerService.updateAudioStream(userId, meetingId.toString(), enabled);
       Optional.ofNullable(audioStreamSettingsDto.getUserToModerate())

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImpl.java
@@ -80,7 +80,7 @@ public class ParticipantServiceImpl implements ParticipantService {
   private void insertMeetingParticipant(
       Meeting meeting, JoinSettingsDto joinSettingsDto, UserPrincipal currentUser) {
     Room room =
-        roomService.getRoomEntityAndCheckUser(
+        roomService.getRoomAndValidateUser(
             UUID.fromString(meeting.getRoomId()), currentUser, false);
     meeting.getParticipants().stream()
         .filter(participant -> participant.getUserId().equals(currentUser.getId()))
@@ -148,7 +148,7 @@ public class ParticipantServiceImpl implements ParticipantService {
                     new NotFoundException(
                         String.format("Meeting with id '%s' not found", meetingId)));
     Room room =
-        roomService.getRoomEntityAndCheckUser(
+        roomService.getRoomAndValidateUser(
             UUID.fromString(meeting.getRoomId()), currentUser, false);
     removeMeetingParticipant(meeting, room, currentUser.getUUID());
   }
@@ -280,8 +280,7 @@ public class ParticipantServiceImpl implements ParticipantService {
                 "User '%s' cannot enable the audio stream of the user '%s'",
                 currentUser.getId(), userId));
       }
-      roomService.getRoomEntityAndCheckUser(
-          UUID.fromString(meeting.getRoomId()), currentUser, true);
+      roomService.getRoomAndValidateUser(UUID.fromString(meeting.getRoomId()), currentUser, true);
     }
     if (participant.hasAudioStreamOn() != enabled) {
       participantRepository.update(participant.audioStreamOn(enabled));
@@ -319,7 +318,7 @@ public class ParticipantServiceImpl implements ParticipantService {
             .getMeetingEntity(meetingId)
             .orElseThrow(
                 () -> new NotFoundException(String.format("Meeting '%s' not found", meetingId)));
-    roomService.getRoomEntityAndCheckUser(UUID.fromString(meeting.getRoomId()), currentUser, false);
+    roomService.getRoomAndValidateUser(UUID.fromString(meeting.getRoomId()), currentUser, false);
     videoServerService.answerRtcMediaStream(currentUser.getId(), meetingId.toString(), sdp);
   }
 
@@ -331,7 +330,7 @@ public class ParticipantServiceImpl implements ParticipantService {
             .getMeetingEntity(meetingId)
             .orElseThrow(
                 () -> new NotFoundException(String.format("Meeting '%s' not found", meetingId)));
-    roomService.getRoomEntityAndCheckUser(UUID.fromString(meeting.getRoomId()), currentUser, false);
+    roomService.getRoomAndValidateUser(UUID.fromString(meeting.getRoomId()), currentUser, false);
     videoServerService.updateSubscriptionsMediaStream(
         currentUser.getId(), meetingId.toString(), subscriptionUpdatesDto);
   }
@@ -343,7 +342,7 @@ public class ParticipantServiceImpl implements ParticipantService {
             .getMeetingEntity(meetingId)
             .orElseThrow(
                 () -> new NotFoundException(String.format("Meeting '%s' not found", meetingId)));
-    roomService.getRoomEntityAndCheckUser(UUID.fromString(meeting.getRoomId()), currentUser, false);
+    roomService.getRoomAndValidateUser(UUID.fromString(meeting.getRoomId()), currentUser, false);
     videoServerService.offerRtcAudioStream(currentUser.getId(), meetingId.toString(), sdp);
   }
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/PreviewServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/PreviewServiceImpl.java
@@ -4,7 +4,6 @@
 
 package com.zextras.carbonio.chats.core.service.impl;
 
-
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.zextras.carbonio.chats.core.data.entity.FileMetadata;
@@ -23,7 +22,6 @@ import com.zextras.carbonio.preview.queries.Query;
 import com.zextras.carbonio.preview.queries.enums.ServiceType;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
-
 import java.util.UUID;
 
 @Singleton
@@ -37,38 +35,43 @@ public class PreviewServiceImpl implements PreviewService {
 
   @Inject
   public PreviewServiceImpl(
-    RoomService roomService,
-    FileMetadataRepository fileMetadataRepository,
-    PreviewClient previewClient
-  ) {
+      RoomService roomService,
+      FileMetadataRepository fileMetadataRepository,
+      PreviewClient previewClient) {
     this.previewClient = previewClient;
     this.roomService = roomService;
     this.fileMetadataRepository = fileMetadataRepository;
   }
 
   private FileResponse remapBlobToDataFile(Try<BlobResponse> response) {
-    return response.map(bResp ->
-      new FileResponse(bResp.getContent(), bResp.getLength(), bResp.getMimeType())
-    ).getOrElseThrow(t -> new PreviewException(t));
+    return response
+        .map(
+            bResp ->
+                Try.of(
+                        () ->
+                            new FileResponse(
+                                bResp.getContent(), bResp.getLength(), bResp.getMimeType()))
+                    .getOrElseThrow(t -> new PreviewException(t)))
+        .getOrElseThrow(t -> new PreviewException(t));
   }
 
   @Override
   public FileResponse getImage(
-    UserPrincipal user,
-    UUID fileId,
-    String area,
-    Option<ImageQualityEnumDto> quality,
-    Option<ImageTypeEnumDto> outputFormat,
-    Option<Boolean> crop
-  ) {
+      UserPrincipal user,
+      UUID fileId,
+      String area,
+      Option<ImageQualityEnumDto> quality,
+      Option<ImageTypeEnumDto> outputFormat,
+      Option<Boolean> crop) {
     validateUser(fileId, user);
 
-    Query.QueryBuilder parameters = new Query.QueryBuilder()
-      .setFileOwnerId(user.getId())
-      .setServiceType(ServiceType.CHATS)
-      .setFileId(fileId.toString())
-      .setVersion(0)
-      .setPreviewArea(area);
+    Query.QueryBuilder parameters =
+        new Query.QueryBuilder()
+            .setFileOwnerId(user.getId())
+            .setServiceType(ServiceType.CHATS)
+            .setFileId(fileId.toString())
+            .setVersion(0)
+            .setPreviewArea(area);
     quality.map(q -> parameters.setQuality(q.toString().toUpperCase()));
     outputFormat.map(f -> parameters.setOutputFormat(f.toString().toUpperCase()));
     crop.map(parameters::setCrop);
@@ -78,21 +81,21 @@ public class PreviewServiceImpl implements PreviewService {
 
   @Override
   public FileResponse getImageThumbnail(
-    UserPrincipal user,
-    UUID fileId,
-    String area,
-    Option<ImageQualityEnumDto> quality,
-    Option<ImageTypeEnumDto> outputFormat,
-    Option<ImageShapeEnumDto> shape
-  ) {
+      UserPrincipal user,
+      UUID fileId,
+      String area,
+      Option<ImageQualityEnumDto> quality,
+      Option<ImageTypeEnumDto> outputFormat,
+      Option<ImageShapeEnumDto> shape) {
     validateUser(fileId, user);
 
-    Query.QueryBuilder parameters = new Query.QueryBuilder()
-      .setFileOwnerId(user.getId())
-      .setServiceType(ServiceType.CHATS)
-      .setFileId(fileId.toString())
-      .setVersion(0)
-      .setPreviewArea(area);
+    Query.QueryBuilder parameters =
+        new Query.QueryBuilder()
+            .setFileOwnerId(user.getId())
+            .setServiceType(ServiceType.CHATS)
+            .setFileId(fileId.toString())
+            .setVersion(0)
+            .setPreviewArea(area);
     quality.map(q -> parameters.setQuality(q.toString().toUpperCase()));
     outputFormat.map(f -> parameters.setOutputFormat(f.toString().toUpperCase()));
     shape.map(s -> parameters.setShape(s.toString().toUpperCase()));
@@ -104,11 +107,12 @@ public class PreviewServiceImpl implements PreviewService {
   public FileResponse getPDF(UserPrincipal user, UUID fileId, Integer firstPage, Integer lastPage) {
     validateUser(fileId, user);
 
-    Query.QueryBuilder parameters = new Query.QueryBuilder()
-      .setFileOwnerId(user.getId())
-      .setServiceType(ServiceType.CHATS)
-      .setFileId(fileId.toString())
-      .setVersion(0);
+    Query.QueryBuilder parameters =
+        new Query.QueryBuilder()
+            .setFileOwnerId(user.getId())
+            .setServiceType(ServiceType.CHATS)
+            .setFileId(fileId.toString())
+            .setVersion(0);
     Option.of(firstPage).peek(parameters::setFirstPage);
     Option.of(lastPage).peek(parameters::setLastPage);
 
@@ -117,21 +121,21 @@ public class PreviewServiceImpl implements PreviewService {
 
   @Override
   public FileResponse getPDFThumbnail(
-    UserPrincipal user,
-    UUID fileId,
-    String area,
-    Option<ImageQualityEnumDto> quality,
-    Option<ImageTypeEnumDto> outputFormat,
-    Option<ImageShapeEnumDto> shape
-  ) {
+      UserPrincipal user,
+      UUID fileId,
+      String area,
+      Option<ImageQualityEnumDto> quality,
+      Option<ImageTypeEnumDto> outputFormat,
+      Option<ImageShapeEnumDto> shape) {
     validateUser(fileId, user);
 
-    Query.QueryBuilder parameters = new Query.QueryBuilder()
-      .setFileOwnerId(user.getId())
-      .setServiceType(ServiceType.CHATS)
-      .setFileId(fileId.toString())
-      .setVersion(0)
-      .setPreviewArea(area);
+    Query.QueryBuilder parameters =
+        new Query.QueryBuilder()
+            .setFileOwnerId(user.getId())
+            .setServiceType(ServiceType.CHATS)
+            .setFileId(fileId.toString())
+            .setVersion(0)
+            .setPreviewArea(area);
     quality.map(q -> parameters.setQuality(q.toString().toUpperCase()));
     outputFormat.map(f -> parameters.setOutputFormat(f.toString().toUpperCase()));
     shape.map(s -> parameters.setShape(s.toString().toUpperCase()));
@@ -140,10 +144,14 @@ public class PreviewServiceImpl implements PreviewService {
   }
 
   private void validateUser(UUID fileId, UserPrincipal user) {
-    FileMetadata originMetadata = fileMetadataRepository.getById(fileId.toString())
-      .orElseThrow(() -> new com.zextras.carbonio.chats.core.exception.NotFoundException(
-        String.format("File with id '%s' not found", fileId)));
-    roomService.getRoomEntityAndCheckUser(UUID.fromString(originMetadata.getRoomId()), user, false);
+    FileMetadata originMetadata =
+        fileMetadataRepository
+            .getById(fileId.toString())
+            .orElseThrow(
+                () ->
+                    new com.zextras.carbonio.chats.core.exception.NotFoundException(
+                        String.format("File with id '%s' not found", fileId)));
+    roomService.getRoomAndValidateUser(UUID.fromString(originMetadata.getRoomId()), user, false);
   }
 
   @Override

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/api/RoomsApiServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/api/RoomsApiServiceImpl.java
@@ -26,6 +26,7 @@ import com.zextras.carbonio.chats.model.RoomDto;
 import com.zextras.carbonio.chats.model.RoomEditableFieldsDto;
 import com.zextras.carbonio.chats.model.RoomExtraFieldDto;
 import com.zextras.carbonio.chats.model.RoomTypeDto;
+import jakarta.validation.Valid;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.SecurityContext;
@@ -255,13 +256,15 @@ public class RoomsApiServiceImpl implements RoomsApiService {
 
   @Override
   @TimedCall
-  public Response insertRoomMember(
-      UUID roomId, MemberToInsertDto memberToInsertDto, SecurityContext securityContext) {
+  public Response insertRoomMembers(
+      UUID roomId,
+      List<@Valid MemberToInsertDto> memberToInsertDto,
+      SecurityContext securityContext) {
     UserPrincipal currentUser =
         Optional.ofNullable((UserPrincipal) securityContext.getUserPrincipal())
             .orElseThrow(UnauthorizedException::new);
     return Response.status(Status.CREATED)
-        .entity(membersService.insertRoomMember(roomId, memberToInsertDto, currentUser))
+        .entity(membersService.insertRoomMembers(roomId, memberToInsertDto, currentUser))
         .build();
   }
 

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/AttachmentServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/AttachmentServiceImplTest.java
@@ -156,7 +156,7 @@ public class AttachmentServiceImplTest {
       assertEquals(file1Id, attachmentsPagination.getAttachments().get(0).getId());
       assertEquals(file2Id, attachmentsPagination.getAttachments().get(1).getId());
       assertNull(attachmentsPagination.getFilter());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(roomService);
     }
 
@@ -219,7 +219,7 @@ public class AttachmentServiceImplTest {
                       PaginationFilter.create(
                           file2Id.toString(), attachmentTimestamp.plusHours(1))));
       assertEquals(expectedFilter, attachmentsPagination.getFilter());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(roomService);
     }
 
@@ -259,7 +259,7 @@ public class AttachmentServiceImplTest {
       assertEquals(1, attachmentsPagination.getAttachments().size());
       assertEquals(file2Id, attachmentsPagination.getAttachments().get(0).getId());
       assertNull(attachmentsPagination.getFilter());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(roomService);
     }
 
@@ -269,7 +269,7 @@ public class AttachmentServiceImplTest {
             + " 'forbidden' exception")
     void getAttachmentInfoByRoomId_testAuthenticatedUserIsNotARoomMember() {
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false))
           .thenThrow(
               new ForbiddenException(
                   String.format(
@@ -284,7 +284,7 @@ public class AttachmentServiceImplTest {
     @DisplayName("Re throws the exception if the room was not found")
     void getAttachmentInfoByRoomId_testRoomNotFound() {
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false))
           .thenThrow(new NotFoundException());
 
       NotFoundException notFoundException =
@@ -310,7 +310,7 @@ public class AttachmentServiceImplTest {
       assertNotNull(attachmentsPagination);
       assertEquals(0, attachmentsPagination.getAttachments().size());
       assertNull(attachmentsPagination.getFilter());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(roomService);
     }
   }
@@ -350,7 +350,7 @@ public class AttachmentServiceImplTest {
       assertNotNull(attachmentById.getMetadata());
       assertEquals(attachmentUuid.toString(), attachmentById.getMetadata().getId());
       verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(storagesService, times(1))
           .getFileStreamById(attachmentUuid.toString(), user1Id.toString());
       verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
@@ -395,7 +395,7 @@ public class AttachmentServiceImplTest {
                       .createdAt(OffsetDateTime.now())
                       .updatedAt(OffsetDateTime.now())
                       .build()));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false))
           .thenThrow(new ForbiddenException());
 
       assertThrows(
@@ -403,7 +403,7 @@ public class AttachmentServiceImplTest {
           () -> attachmentService.getAttachmentById(attachmentUuid, currentUser));
 
       verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(fileMetadataRepository, roomService);
       verifyNoInteractions(storagesService);
     }
@@ -427,7 +427,7 @@ public class AttachmentServiceImplTest {
                       .createdAt(OffsetDateTime.now())
                       .updatedAt(OffsetDateTime.now())
                       .build()));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false))
           .thenThrow(new NotFoundException());
 
       NotFoundException notFoundException =
@@ -437,7 +437,7 @@ public class AttachmentServiceImplTest {
       assertEquals("Not Found - Not Found", notFoundException.getMessage());
 
       verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(fileMetadataRepository, roomService);
       verifyNoInteractions(storagesService);
     }
@@ -468,7 +468,7 @@ public class AttachmentServiceImplTest {
           () -> attachmentService.getAttachmentById(attachmentUuid, currentUser));
 
       verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(storagesService, times(1))
           .getFileStreamById(attachmentUuid.toString(), user1Id.toString());
       verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
@@ -504,7 +504,7 @@ public class AttachmentServiceImplTest {
 
       assertNotNull(attachmentInfo);
       assertEquals(attachmentUuid, attachmentInfo.getId());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(roomService);
     }
 
@@ -543,7 +543,7 @@ public class AttachmentServiceImplTest {
               .build();
       when(fileMetadataRepository.getById(attachmentUuid.toString()))
           .thenReturn(Optional.of(metadata));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false))
           .thenThrow(new ForbiddenException());
 
       assertThrows(
@@ -570,7 +570,7 @@ public class AttachmentServiceImplTest {
               .build();
       when(fileMetadataRepository.getById(attachmentUuid.toString()))
           .thenReturn(Optional.of(metadata));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false))
           .thenThrow(new NotFoundException());
 
       NotFoundException notFoundException =
@@ -591,7 +591,7 @@ public class AttachmentServiceImplTest {
       UUID attachmentUuid = UUID.randomUUID();
       OffsetDateTime attachmentDate = OffsetDateTime.parse("2022-01-01T00:00:00Z");
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room1);
       InputStream fileStream = mock(InputStream.class);
       FileMetadataBuilder metadataBuilder =
           FileMetadataBuilder.create()
@@ -623,7 +623,7 @@ public class AttachmentServiceImplTest {
             currentUser);
       }
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(storagesService, times(1))
           .saveFile(fileStream, attachmentUuid.toString(), currentUser.toString(), 1024L);
       verify(fileMetadataRepository, times(1)).save(expectedMetadata);
@@ -636,7 +636,7 @@ public class AttachmentServiceImplTest {
       UUID attachmentUuid = UUID.randomUUID();
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
       InputStream fileStream = mock(InputStream.class);
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false))
           .thenThrow(new NotFoundException());
       try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
         uuid.when(UUID::randomUUID).thenReturn(attachmentUuid);
@@ -657,7 +657,7 @@ public class AttachmentServiceImplTest {
                     currentUser));
       }
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
     }
 
@@ -667,7 +667,7 @@ public class AttachmentServiceImplTest {
       UUID attachmentUuid = UUID.randomUUID();
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
       InputStream fileStream = mock(InputStream.class);
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false))
           .thenThrow(new ForbiddenException());
       try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
         uuid.when(UUID::randomUUID).thenReturn(attachmentUuid);
@@ -688,7 +688,7 @@ public class AttachmentServiceImplTest {
                     currentUser));
       }
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
     }
 
@@ -698,7 +698,7 @@ public class AttachmentServiceImplTest {
       UUID attachmentUuid = UUID.randomUUID();
       UserPrincipal currentUser = UserPrincipal.create(user1Id);
       InputStream fileStream = mock(InputStream.class);
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room1);
       doThrow(new StorageException())
           .when(storagesService)
           .saveFile(fileStream, attachmentUuid.toString(), user1Id.toString(), 1024L);
@@ -721,7 +721,7 @@ public class AttachmentServiceImplTest {
                     currentUser));
       }
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(storagesService, times(1))
           .saveFile(fileStream, attachmentUuid.toString(), currentUser.getId(), 1024L);
       verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
@@ -749,7 +749,7 @@ public class AttachmentServiceImplTest {
       FileMetadata fileMetadata = metadataBuilder.build();
       when(fileMetadataRepository.getById(originalAttachmentId.toString()))
           .thenReturn(Optional.of(fileMetadata));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room1);
       UUID attachmentUuid = UUID.randomUUID();
       try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
         uuid.when(UUID::randomUUID).thenReturn(attachmentUuid);
@@ -759,7 +759,7 @@ public class AttachmentServiceImplTest {
       }
 
       verify(fileMetadataRepository, times(1)).getById(originalAttachmentId.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(storagesService, times(1))
           .copyFile(
               originalAttachmentId.toString(),
@@ -797,7 +797,7 @@ public class AttachmentServiceImplTest {
       FileMetadata fileMetadata = metadataBuilder.build();
       when(fileMetadataRepository.getById(originalAttachmentId.toString()))
           .thenReturn(Optional.of(fileMetadata));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false))
           .thenThrow(NotFoundException.class);
       try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
         uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
@@ -809,7 +809,7 @@ public class AttachmentServiceImplTest {
       }
 
       verify(fileMetadataRepository, times(1)).getById(originalAttachmentId.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
     }
 
@@ -830,7 +830,7 @@ public class AttachmentServiceImplTest {
       FileMetadata fileMetadata = metadataBuilder.build();
       when(fileMetadataRepository.getById(originalAttachmentId.toString()))
           .thenReturn(Optional.of(fileMetadata));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false))
           .thenThrow(ForbiddenException.class);
       try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
         uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
@@ -842,7 +842,7 @@ public class AttachmentServiceImplTest {
       }
 
       verify(fileMetadataRepository, times(1)).getById(originalAttachmentId.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(roomService, storagesService, fileMetadataRepository);
     }
 
@@ -863,7 +863,7 @@ public class AttachmentServiceImplTest {
       FileMetadata fileMetadata = metadataBuilder.build();
       when(fileMetadataRepository.getById(originalAttachmentId.toString()))
           .thenReturn(Optional.of(fileMetadata));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room1);
       UUID attachmentUuid = UUID.randomUUID();
       doThrow(StorageException.class)
           .when(storagesService)
@@ -883,7 +883,7 @@ public class AttachmentServiceImplTest {
       }
 
       verify(fileMetadataRepository, times(1)).getById(originalAttachmentId.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(storagesService, times(1))
           .copyFile(
               originalAttachmentId.toString(),
@@ -914,12 +914,12 @@ public class AttachmentServiceImplTest {
               .build();
       when(fileMetadataRepository.getById(attachmentUuid.toString()))
           .thenReturn(Optional.of(expectedMetadata));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room1);
 
       attachmentService.deleteAttachment(attachmentUuid, currentUser);
 
       verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(storagesService, times(1)).deleteFile(attachmentUuid.toString(), user2Id.toString());
       verify(fileMetadataRepository, times(1)).delete(expectedMetadata);
       verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
@@ -941,12 +941,12 @@ public class AttachmentServiceImplTest {
               .build();
       when(fileMetadataRepository.getById(attachmentUuid.toString()))
           .thenReturn(Optional.of(expectedMetadata));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room1);
 
       attachmentService.deleteAttachment(attachmentUuid, currentUser);
 
       verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(storagesService, times(1)).deleteFile(attachmentUuid.toString(), user2Id.toString());
       verify(fileMetadataRepository, times(1)).delete(expectedMetadata);
       verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
@@ -983,7 +983,7 @@ public class AttachmentServiceImplTest {
               .build();
       when(fileMetadataRepository.getById(attachmentUuid.toString()))
           .thenReturn(Optional.of(expectedMetadata));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false))
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false))
           .thenThrow(new NotFoundException());
 
       assertThrows(
@@ -991,7 +991,7 @@ public class AttachmentServiceImplTest {
           () -> attachmentService.deleteAttachment(attachmentUuid, currentUser));
 
       verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
     }
 
@@ -1011,7 +1011,7 @@ public class AttachmentServiceImplTest {
               .build();
       when(fileMetadataRepository.getById(attachmentUuid.toString()))
           .thenReturn(Optional.of(expectedMetadata));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room1);
       doThrow(new StorageException())
           .when(storagesService)
           .deleteFile(attachmentUuid.toString(), user2Id.toString());
@@ -1021,7 +1021,7 @@ public class AttachmentServiceImplTest {
           () -> attachmentService.deleteAttachment(attachmentUuid, currentUser));
 
       verify(fileMetadataRepository, times(1)).getById(attachmentUuid.toString());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(storagesService, times(1)).deleteFile(attachmentUuid.toString(), user2Id.toString());
       verifyNoMoreInteractions(fileMetadataRepository, roomService, storagesService);
     }
@@ -1043,7 +1043,7 @@ public class AttachmentServiceImplTest {
               .build();
       when(fileMetadataRepository.getById(attachmentUuid.toString()))
           .thenReturn(Optional.of(expectedMetadata));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room1);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room1);
 
       assertThrows(
           ForbiddenException.class,

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MeetingServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MeetingServiceImplTest.java
@@ -77,13 +77,13 @@ public class MeetingServiceImplTest {
     this.clock = mock(Clock.class);
     this.meetingService =
         new MeetingServiceImpl(
-            this.meetingRepository,
+            meetingRepository,
             meetingMapper,
-            this.roomService,
-            this.membersService,
-            this.videoServerService,
-            this.eventDispatcher,
-            this.clock);
+            roomService,
+            membersService,
+            videoServerService,
+            eventDispatcher,
+            clock);
   }
 
   private UUID user1Id;
@@ -202,7 +202,7 @@ public class MeetingServiceImplTest {
               .meetingType(meetingType)
               .roomId(room1Id.toString())
               .active(false);
-      when(roomService.getRoomEntityAndCheckUser(room1Id, user, false)).thenReturn(room1);
+      when(roomService.getRoomAndValidateUser(room1Id, user, false)).thenReturn(room1);
       when(meetingRepository.insert(any(Meeting.class))).thenReturn(meeting);
 
       MeetingDto createdMeeting =
@@ -216,7 +216,7 @@ public class MeetingServiceImplTest {
     void createMeetingFromRoom_testKO() {
       UserPrincipal user = UserPrincipal.create(user1Id);
       String meetingName = "test";
-      when(roomService.getRoomEntityAndCheckUser(room2Id, user, false)).thenReturn(room2);
+      when(roomService.getRoomAndValidateUser(room2Id, user, false)).thenReturn(room2);
 
       assertThrows(
           ConflictException.class,
@@ -608,7 +608,7 @@ public class MeetingServiceImplTest {
     @Test
     @DisplayName("Returns the meeting of the required with all participants")
     void getMeetingByRoomId_testOk() {
-      when(roomService.getRoomEntityAndCheckUser(room1Id, UserPrincipal.create(user1Id), false))
+      when(roomService.getRoomAndValidateUser(room1Id, UserPrincipal.create(user1Id), false))
           .thenReturn(room1);
       when(meetingRepository.getByRoomId(room1Id.toString())).thenReturn(Optional.of(meeting1));
 
@@ -640,7 +640,7 @@ public class MeetingServiceImplTest {
       assertTrue(participant1.get().isAudioStreamEnabled());
 
       verify(roomService, times(1))
-          .getRoomEntityAndCheckUser(room1Id, UserPrincipal.create(user1Id), false);
+          .getRoomAndValidateUser(room1Id, UserPrincipal.create(user1Id), false);
       verify(meetingRepository, times(1)).getByRoomId(room1Id.toString());
       verifyNoMoreInteractions(meetingRepository, roomService);
       verifyNoInteractions(membersService, videoServerService, eventDispatcher);
@@ -649,7 +649,7 @@ public class MeetingServiceImplTest {
     @Test
     @DisplayName("If the room meeting doesn't exists, it throws a 'not found' exception")
     void getMeetingByRoomId_testMeetingNotExists() {
-      when(roomService.getRoomEntityAndCheckUser(room1Id, UserPrincipal.create(user1Id), false))
+      when(roomService.getRoomAndValidateUser(room1Id, UserPrincipal.create(user1Id), false))
           .thenReturn(room1);
       when(meetingRepository.getByRoomId(room1Id.toString())).thenReturn(Optional.empty());
 
@@ -665,7 +665,7 @@ public class MeetingServiceImplTest {
           exception.getMessage());
 
       verify(roomService, times(1))
-          .getRoomEntityAndCheckUser(room1Id, UserPrincipal.create(user1Id), false);
+          .getRoomAndValidateUser(room1Id, UserPrincipal.create(user1Id), false);
       verify(meetingRepository, times(1)).getByRoomId(room1Id.toString());
       verifyNoMoreInteractions(roomService, meetingRepository);
       verifyNoInteractions(membersService, videoServerService, eventDispatcher);
@@ -680,7 +680,7 @@ public class MeetingServiceImplTest {
     @DisplayName("Deletes the requested meeting")
     void deleteMeetingById_testOk() {
       when(meetingRepository.getById(meeting1Id.toString())).thenReturn(Optional.of(meeting1));
-      when(roomService.getRoomEntityAndCheckUser(room1Id, UserPrincipal.create(user1Id), false))
+      when(roomService.getRoomAndValidateUser(room1Id, UserPrincipal.create(user1Id), false))
           .thenReturn(room1);
 
       meetingService.deleteMeetingById(meeting1Id, UserPrincipal.create(user1Id));
@@ -688,7 +688,7 @@ public class MeetingServiceImplTest {
       verify(meetingRepository, times(1)).getById(meeting1Id.toString());
       verify(meetingRepository, times(1)).delete(meeting1);
       verify(roomService, times(1))
-          .getRoomEntityAndCheckUser(room1Id, UserPrincipal.create(user1Id), false);
+          .getRoomAndValidateUser(room1Id, UserPrincipal.create(user1Id), false);
       verify(videoServerService, times(1)).stopMeeting(meeting1Id.toString());
       verify(eventDispatcher, times(1))
           .sendToUserExchange(

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MeetingServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MeetingServiceImplTest.java
@@ -450,8 +450,8 @@ public class MeetingServiceImplTest {
     @DisplayName("Returns the required meeting with all participants")
     void getMeetingById_testOk() {
       when(meetingRepository.getById(meeting1Id.toString())).thenReturn(Optional.of(meeting1));
-      when(membersService.getByUserIdAndRoomId(user1Id, room1Id))
-          .thenReturn(Optional.of(MemberDto.create()));
+      when(membersService.getSubscription(user1Id, room1Id))
+          .thenReturn(Optional.of(Subscription.create()));
 
       MeetingDto meetingDto =
           meetingService.getMeetingById(meeting1Id, UserPrincipal.create(user1Id));
@@ -481,7 +481,7 @@ public class MeetingServiceImplTest {
       assertTrue(participant1.get().isAudioStreamEnabled());
 
       verify(meetingRepository, times(1)).getById(meeting1Id.toString());
-      verify(membersService, times(1)).getByUserIdAndRoomId(user1Id, room1Id);
+      verify(membersService, times(1)).getSubscription(user1Id, room1Id);
       verifyNoMoreInteractions(meetingRepository, membersService);
       verifyNoInteractions(roomService, videoServerService, eventDispatcher);
     }
@@ -491,7 +491,7 @@ public class MeetingServiceImplTest {
         "If the authenticated user isn't a room meeting member, it throws a 'forbidden' exception")
     void getMeetingById_testUserNotRoomMeetingMember() {
       when(meetingRepository.getById(meeting1Id.toString())).thenReturn(Optional.of(meeting1));
-      when(membersService.getByUserIdAndRoomId(user1Id, room1Id)).thenReturn(Optional.empty());
+      when(membersService.getSubscription(user1Id, room1Id)).thenReturn(Optional.empty());
 
       ChatsHttpException exception =
           assertThrows(
@@ -507,7 +507,7 @@ public class MeetingServiceImplTest {
           exception.getMessage());
 
       verify(meetingRepository, times(1)).getById(meeting1Id.toString());
-      verify(membersService, times(1)).getByUserIdAndRoomId(user1Id, room1Id);
+      verify(membersService, times(1)).getSubscription(user1Id, room1Id);
       verifyNoMoreInteractions(meetingRepository, membersService);
       verifyNoInteractions(roomService, videoServerService, eventDispatcher);
     }
@@ -724,7 +724,7 @@ public class MeetingServiceImplTest {
         "If the authenticated user isn't a room meeting member, it throws a 'forbidden' exception")
     void getMeetingById_testUserNotRoomMeetingMember() {
       when(meetingRepository.getById(meeting1Id.toString())).thenReturn(Optional.of(meeting1));
-      when(membersService.getByUserIdAndRoomId(user1Id, room1Id)).thenReturn(Optional.empty());
+      when(membersService.getSubscription(user1Id, room1Id)).thenReturn(Optional.empty());
 
       ChatsHttpException exception =
           assertThrows(
@@ -740,7 +740,7 @@ public class MeetingServiceImplTest {
           exception.getMessage());
 
       verify(meetingRepository, times(1)).getById(meeting1Id.toString());
-      verify(membersService, times(1)).getByUserIdAndRoomId(user1Id, room1Id);
+      verify(membersService, times(1)).getSubscription(user1Id, room1Id);
       verifyNoMoreInteractions(meetingRepository, membersService);
       verifyNoInteractions(roomService, videoServerService, eventDispatcher);
     }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImplTest.java
@@ -121,11 +121,11 @@ public class MembersServiceImplTest {
 
   @Nested
   @DisplayName("Sets or remove a user as room owner tests")
-  public class SetsOwnerTests {
+  class SetsOwnerTests {
 
     @Test
     @DisplayName("Correctly set a user as room owner")
-    public void setOwner_testOk() {
+    void setOwner_testOk() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       Subscription user2subscription = Subscription.create(room, user2Id.toString()).owner(false);
       room.subscriptions(
@@ -148,7 +148,7 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("Correctly remove a user as room owner")
-    public void removeOwner_testOk() {
+    void removeOwner_testOk() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       Subscription user2subscription = Subscription.create(room, user2Id.toString()).owner(true);
       room.subscriptions(
@@ -171,7 +171,7 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("If the user isn't a room member, it throws a 'forbidden' exception")
-    public void setRemoveOwner_userNotARoomMember() {
+    void setRemoveOwner_userNotARoomMember() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       room.subscriptions(
           List.of(
@@ -195,7 +195,7 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("If the room is a one-to-one room, it throws a 'bad request' exception")
-    public void setRemoveOwner_roomIsOneToOne() {
+    void setRemoveOwner_roomIsOneToOne() {
       Room room = generateRoom(RoomTypeDto.ONE_TO_ONE);
       room.subscriptions(
           List.of(
@@ -218,7 +218,7 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("If the user is the requester, it throws a 'bad request' exception")
-    public void setRemoveOwner_userIsRequester() {
+    void setRemoveOwner_userIsRequester() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       room.subscriptions(
           List.of(
@@ -241,11 +241,11 @@ public class MembersServiceImplTest {
 
   @Nested
   @DisplayName("Adds a member to a room tests")
-  public class InsertsRoomMemberTests {
+  class InsertsRoomMemberTests {
 
     @Test
     @DisplayName("Correctly adds a user as a member of group room")
-    public void insertGroupRoomMember_testOk() {
+    void insertGroupRoomMember_testOk() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       room.subscriptions(
           new ArrayList<>(
@@ -283,7 +283,7 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("if the room is a one-to-one room, it throws a 'bad request' exception")
-    public void insertOneToOneRoomMember_testNo() {
+    void insertOneToOneRoomMember_testNo() {
       Room room = generateRoom(RoomTypeDto.ONE_TO_ONE);
       room.subscriptions(
           List.of(
@@ -313,7 +313,7 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("If user is already a room member, it throws a 'bad request' exception")
-    public void insertRoomMember_userIsAlreadyARoomMember() {
+    void insertRoomMember_userIsAlreadyARoomMember() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       room.subscriptions(
           List.of(
@@ -348,7 +348,7 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("If the user doesn't exist, it throws a 'not found' exception")
-    public void insertRoomMember_userNotExists() {
+    void insertRoomMember_userNotExists() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       room.subscriptions(
           List.of(
@@ -382,7 +382,7 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("Correctly adds a user as a member of group room clearing history")
-    public void insertRoomMember_historyCleared() {
+    void insertRoomMember_historyCleared() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       room.subscriptions(
           new ArrayList<>(
@@ -435,7 +435,7 @@ public class MembersServiceImplTest {
     @Test
     @DisplayName(
         "Reached max group members when inviting a user, it throws a 'bad request' exception")
-    public void insertRoomMember_maxGroupMembers() {
+    void insertRoomMember_maxGroupMembers() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       room.subscriptions(
           List.of(
@@ -469,11 +469,11 @@ public class MembersServiceImplTest {
 
   @Nested
   @DisplayName("Removes a member from a room tests")
-  public class DeletesRoomMemberTests {
+  class DeletesRoomMemberTests {
 
     @Test
     @DisplayName("Correctly removes a member of a group room")
-    public void deleteRoomMember_groupTestOk() {
+    void deleteRoomMember_groupTestOk() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       room.subscriptions(
           List.of(
@@ -500,7 +500,7 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("Correctly user removes itself of a group room")
-    public void deleteRoomMember_userRemoveItselfTestOk() {
+    void deleteRoomMember_userRemoveItselfTestOk() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       room.subscriptions(
           List.of(
@@ -527,7 +527,7 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("If user is the last room owner, it throws a 'bad request' exception")
-    public void deleteRoomMember_userIsTheLastOwner() {
+    void deleteRoomMember_userIsTheLastOwner() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       room.subscriptions(
           List.of(
@@ -552,7 +552,7 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("If room is a one-to-one room, it throws a 'bad request' exception")
-    public void deleteRoomMember_roomIsAOneToOne() {
+    void deleteRoomMember_roomIsAOneToOne() {
       Room room = generateRoom(RoomTypeDto.ONE_TO_ONE);
       room.subscriptions(
           List.of(
@@ -581,11 +581,11 @@ public class MembersServiceImplTest {
 
   @Nested
   @DisplayName("Retrieves all room members list tests")
-  public class GetsRoomMembersTest {
+  class GetsRoomMembersTest {
 
     @Test
     @DisplayName("Correctly gets all group members")
-    public void getGroupMembers_testOk() {
+    void getGroupMembers_testOk() {
       Room room = generateRoom(RoomTypeDto.GROUP);
       room.subscriptions(
           List.of(
@@ -608,16 +608,18 @@ public class MembersServiceImplTest {
 
   @Nested
   @DisplayName("Initialize the room subscriptions")
-  public class InitRoomSubscriptionsTests {
+  class InitRoomSubscriptionsTests {
 
     @Test
     @DisplayName("Correctly initialize a group room subscriptions")
-    public void initRoomSubscriptions_groupRoom() {
+    void initRoomSubscriptions_groupRoom() {
       List<Subscription> subscriptions =
           membersService.initRoomSubscriptions(
-              List.of(user1Id, user2Id, user3Id),
-              generateRoom(RoomTypeDto.GROUP),
-              UserPrincipal.create(user2Id));
+              List.of(
+                  MemberDto.create().userId(user1Id),
+                  MemberDto.create().userId(user2Id).owner(true),
+                  MemberDto.create().userId(user3Id)),
+              generateRoom(RoomTypeDto.GROUP));
       assertNotNull(subscriptions);
       assertEquals(3, subscriptions.size());
 
@@ -636,12 +638,11 @@ public class MembersServiceImplTest {
 
     @Test
     @DisplayName("Correctly initialize a one-to-one room subscriptions")
-    public void initRoomSubscriptions_oneToOneRoom() {
+    void initRoomSubscriptions_oneToOneRoom() {
       List<Subscription> subscriptions =
           membersService.initRoomSubscriptions(
-              List.of(user1Id, user2Id),
-              generateRoom(RoomTypeDto.ONE_TO_ONE),
-              UserPrincipal.create(user2Id));
+              List.of(MemberDto.create().userId(user1Id), MemberDto.create().userId(user2Id)),
+              generateRoom(RoomTypeDto.ONE_TO_ONE));
       assertNotNull(subscriptions);
       assertEquals(2, subscriptions.size());
 

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImplTest.java
@@ -134,7 +134,7 @@ public class MembersServiceImplTest {
               user2subscription,
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
       membersService.setOwner(roomId, user2Id, true, principal);
 
       verify(subscriptionRepository, times(1)).update(user2subscription.owner(true));
@@ -157,7 +157,7 @@ public class MembersServiceImplTest {
               user2subscription,
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
       membersService.setOwner(roomId, user2Id, false, principal);
 
       verify(subscriptionRepository, times(1)).update(user2subscription.owner(false));
@@ -178,7 +178,7 @@ public class MembersServiceImplTest {
               Subscription.create(room, user1Id.toString()).owner(true),
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
 
       ChatsHttpException exception =
           assertThrows(
@@ -202,7 +202,7 @@ public class MembersServiceImplTest {
               Subscription.create(room, user1Id.toString()).owner(true),
               Subscription.create(room, user2Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
 
       ChatsHttpException exception =
           assertThrows(
@@ -225,7 +225,7 @@ public class MembersServiceImplTest {
               Subscription.create(room, user1Id.toString()).owner(true),
               Subscription.create(room, user2Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user2Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
 
       ChatsHttpException exception =
           assertThrows(
@@ -254,7 +254,7 @@ public class MembersServiceImplTest {
                   Subscription.create(room, user3Id.toString()).owner(false))));
       UserPrincipal principal = UserPrincipal.create(user1Id);
 
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
       when(capabilityService.getCapabilities(principal))
           .thenReturn(CapabilitiesDto.create().maxGroupMembers(128));
       when(userService.userExists(user2Id, principal)).thenReturn(true);
@@ -271,7 +271,7 @@ public class MembersServiceImplTest {
       assertNotNull(memberInsertedDto);
       assertEquals(user2Id, memberInsertedDto.getUserId());
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, principal, true);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(userService, times(1)).userExists(user2Id, principal);
       verify(messageDispatcher, times(1))
           .addRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
@@ -295,7 +295,7 @@ public class MembersServiceImplTest {
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
 
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
       ChatsHttpException exception =
           assertThrows(
               BadRequestException.class,
@@ -307,7 +307,7 @@ public class MembersServiceImplTest {
       assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
       assertEquals(
           "Bad Request - Cannot add members to a one_to_one conversation", exception.getMessage());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, principal, true);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
 
       verifyNoMoreInteractions(roomService, roomUserSettingsRepository);
       verifyNoInteractions(userService, subscriptionRepository, eventDispatcher, messageDispatcher);
@@ -324,7 +324,7 @@ public class MembersServiceImplTest {
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
 
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
       when(capabilityService.getCapabilities(principal))
           .thenReturn(CapabilitiesDto.create().maxGroupMembers(128));
 
@@ -339,7 +339,7 @@ public class MembersServiceImplTest {
       assertEquals(
           String.format("Bad Request - User '%s' is already a room member", user2Id.toString()),
           exception.getMessage());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, principal, true);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
 
       verifyNoMoreInteractions(roomService);
       verifyNoInteractions(
@@ -360,7 +360,7 @@ public class MembersServiceImplTest {
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
 
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
       when(capabilityService.getCapabilities(principal))
           .thenReturn(CapabilitiesDto.create().maxGroupMembers(128));
       when(userService.userExists(user2Id, principal)).thenReturn(false);
@@ -376,7 +376,7 @@ public class MembersServiceImplTest {
       assertEquals(
           String.format("Not Found - User with id '%s' not found", user2Id),
           exception.getMessage());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, principal, true);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(userService, times(1)).userExists(user2Id, principal);
 
       verifyNoMoreInteractions(roomService, userService);
@@ -395,7 +395,7 @@ public class MembersServiceImplTest {
                   Subscription.create(room, user3Id.toString()).owner(false))));
       UserPrincipal principal = UserPrincipal.create(user1Id);
 
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
       when(userService.userExists(user2Id, principal)).thenReturn(true);
       when(subscriptionRepository.insert(any(Subscription.class)))
           .thenReturn(Subscription.create(room, user2Id.toString()));
@@ -414,7 +414,7 @@ public class MembersServiceImplTest {
       assertNotNull(memberInsertedDto);
       assertEquals(user2Id, memberInsertedDto.getUserId());
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, principal, true);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(userService, times(1)).userExists(user2Id, principal);
       verify(messageDispatcher, times(1))
           .addRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
@@ -450,7 +450,7 @@ public class MembersServiceImplTest {
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
 
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
       when(capabilityService.getCapabilities(principal))
           .thenReturn(CapabilitiesDto.create().maxGroupMembers(3));
       ChatsHttpException exception =
@@ -462,7 +462,7 @@ public class MembersServiceImplTest {
       assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
       assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
       assertEquals("Bad Request - Cannot add more members to this group", exception.getMessage());
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, principal, true);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(capabilityService, times(1)).getCapabilities(principal);
 
       verifyNoMoreInteractions(roomService, capabilityService);
@@ -489,11 +489,11 @@ public class MembersServiceImplTest {
               Subscription.create(room, user2Id.toString()).owner(false),
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
 
       membersService.deleteRoomMember(roomId, user2Id, principal);
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, principal, true);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(messageDispatcher, times(1))
           .removeRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
       verify(roomUserSettingsRepository, times(1))
@@ -521,11 +521,11 @@ public class MembersServiceImplTest {
               Subscription.create(room, user2Id.toString()).owner(true),
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, false)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, false)).thenReturn(room);
 
       membersService.deleteRoomMember(roomId, user1Id, principal);
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, principal, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, false);
       verify(messageDispatcher, times(1))
           .removeRoomMember(roomId.toString(), user2Id.toString(), user1Id.toString());
       verify(roomUserSettingsRepository, times(1))
@@ -553,7 +553,7 @@ public class MembersServiceImplTest {
               Subscription.create(room, user2Id.toString()).owner(false),
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, false)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, false)).thenReturn(room);
 
       ChatsHttpException exception =
           assertThrows(
@@ -563,7 +563,7 @@ public class MembersServiceImplTest {
       assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
       assertEquals("Bad Request - Last owner can't leave the room", exception.getMessage());
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, principal, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, false);
       verifyNoMoreInteractions(roomService);
       verifyNoInteractions(subscriptionRepository, eventDispatcher, messageDispatcher);
     }
@@ -578,7 +578,7 @@ public class MembersServiceImplTest {
               Subscription.create(room, user2Id.toString()).owner(false),
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, true)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
 
       ChatsHttpException exception =
           assertThrows(
@@ -591,7 +591,7 @@ public class MembersServiceImplTest {
           "Bad Request - Cannot remove a member from a one_to_one conversation",
           exception.getMessage());
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, principal, true);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verifyNoMoreInteractions(roomService);
       verifyNoInteractions(subscriptionRepository, eventDispatcher, messageDispatcher);
     }
@@ -611,7 +611,7 @@ public class MembersServiceImplTest {
               Subscription.create(room, user2Id.toString()).owner(false),
               Subscription.create(room, user3Id.toString()).owner(false)));
       UserPrincipal principal = UserPrincipal.create(user1Id);
-      when(roomService.getRoomEntityAndCheckUser(roomId, principal, false)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, principal, false)).thenReturn(room);
       List<MemberDto> roomMembers = membersService.getRoomMembers(roomId, principal);
       assertNotNull(roomMembers);
       assertEquals(3, roomMembers.size());
@@ -619,7 +619,7 @@ public class MembersServiceImplTest {
       assertEquals(user2Id, roomMembers.get(1).getUserId());
       assertEquals(user3Id, roomMembers.get(2).getUserId());
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, principal, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, false);
       verifyNoMoreInteractions(roomService);
     }
   }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImplTest.java
@@ -76,12 +76,12 @@ public class ParticipantServiceImplTest {
     this.clock = mock(Clock.class);
     this.participantService =
         new ParticipantServiceImpl(
-            this.meetingService,
-            this.roomService,
-            this.participantRepository,
-            this.videoServerService,
-            this.eventDispatcher,
-            this.clock);
+            meetingService,
+            roomService,
+            participantRepository,
+            videoServerService,
+            eventDispatcher,
+            clock);
   }
 
   private UUID user1Id;

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImplTest.java
@@ -178,7 +178,7 @@ public class ParticipantServiceImplTest {
     void insertMeetingParticipant_testOk() {
       UserPrincipal currentUser = UserPrincipal.create(user3Id).queueId(user3Queue1);
       when(meetingService.getMeetingEntity(meeting1Id)).thenReturn(Optional.of(meeting1));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room);
 
       participantService.insertMeetingParticipant(
           meeting1Id,
@@ -186,7 +186,7 @@ public class ParticipantServiceImplTest {
           currentUser);
 
       verify(meetingService, times(1)).getMeetingEntity(meeting1Id);
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(participantRepository, times(1))
           .insert(
               Participant.create(meeting1, user3Id.toString())
@@ -209,7 +209,7 @@ public class ParticipantServiceImplTest {
       UUID newQueue = UUID.randomUUID();
       UserPrincipal currentUser = UserPrincipal.create(user2Id).queueId(newQueue);
       when(meetingService.getMeetingEntity(meeting1Id)).thenReturn(Optional.of(meeting1));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room);
 
       participantService.insertMeetingParticipant(
           meeting1Id,
@@ -218,7 +218,7 @@ public class ParticipantServiceImplTest {
 
       verify(meetingService, times(1)).getMeetingEntity(meeting1Id);
 
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(videoServerService, times(1))
           .destroyMeetingParticipant(user2Id.toString(), meeting1Id.toString());
       verify(eventDispatcher, times(1))
@@ -269,7 +269,7 @@ public class ParticipantServiceImplTest {
       assertEquals("Conflict - User is already inserted into the meeting", exception.getMessage());
 
       verify(meetingService, times(1)).getMeetingEntity(meeting1Id);
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(roomService, meetingService);
       verifyNoInteractions(participantRepository, videoServerService, eventDispatcher);
     }
@@ -284,14 +284,14 @@ public class ParticipantServiceImplTest {
     void removeMeetingParticipant_testOk() {
       UserPrincipal currentUser = UserPrincipal.create(user4Id).queueId(user4Queue1);
       when(meetingService.getMeetingEntity(meeting1Id)).thenReturn(Optional.of(meeting1));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room);
       when(participantRepository.getByMeetingId(meeting1Id.toString()))
           .thenReturn(List.of(participant2Session1));
 
       participantService.removeMeetingParticipant(meeting1Id, currentUser);
 
       verify(meetingService, times(1)).getMeetingEntity(meeting1Id);
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(participantRepository, times(1)).remove(participant4Session1);
       verify(participantRepository, times(1)).getByMeetingId(meeting1Id.toString());
       verify(videoServerService, times(1))
@@ -311,13 +311,13 @@ public class ParticipantServiceImplTest {
     void removeMeetingParticipant_testOkLastParticipant() {
       UserPrincipal currentUser = UserPrincipal.create(user2Id).queueId(user2Queue1);
       when(meetingService.getMeetingEntity(meeting2Id)).thenReturn(Optional.of(meeting2));
-      when(roomService.getRoomEntityAndCheckUser(roomId, currentUser, false)).thenReturn(room);
+      when(roomService.getRoomAndValidateUser(roomId, currentUser, false)).thenReturn(room);
       when(participantRepository.getByMeetingId(meeting2Id.toString())).thenReturn(List.of());
 
       participantService.removeMeetingParticipant(meeting2Id, currentUser);
 
       verify(meetingService, times(1)).getMeetingEntity(meeting2Id);
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verify(participantRepository, times(1)).remove(participant2Session1);
       verify(participantRepository, times(1)).getByMeetingId(meeting2Id.toString());
       verify(videoServerService, times(1))
@@ -341,7 +341,7 @@ public class ParticipantServiceImplTest {
       participantService.removeMeetingParticipant(meeting1Id, currentUser);
 
       verify(meetingService, times(1)).getMeetingEntity(meeting1Id);
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, false);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
       verifyNoMoreInteractions(meetingService, roomService);
       verifyNoInteractions(participantRepository, videoServerService, eventDispatcher);
     }
@@ -741,7 +741,7 @@ public class ParticipantServiceImplTest {
           currentUser);
 
       verify(meetingService, times(1)).getMeetingEntity(meeting1Id);
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, true);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, true);
       verify(participantRepository, times(1))
           .update(
               ParticipantBuilder.create(Meeting.create(), user4Id.toString())
@@ -779,7 +779,7 @@ public class ParticipantServiceImplTest {
           currentUser);
 
       verify(meetingService, times(1)).getMeetingEntity(meeting1Id);
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, currentUser, true);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, true);
       verifyNoMoreInteractions(meetingService, roomService);
       verifyNoInteractions(participantRepository, eventDispatcher, videoServerService);
     }
@@ -845,7 +845,7 @@ public class ParticipantServiceImplTest {
     void disableAudioStream_testErrorUserIsNotAModerator() {
       UserPrincipal user = UserPrincipal.create(user1Id).queueId(user1Queue1);
       when(meetingService.getMeetingEntity(meeting1Id)).thenReturn(Optional.of(meeting1));
-      when(roomService.getRoomEntityAndCheckUser(roomId, user, true))
+      when(roomService.getRoomAndValidateUser(roomId, user, true))
           .thenThrow(
               new ForbiddenException(
                   String.format("User '%s' is not an owner of room '%s'", user.getId(), roomId)));
@@ -869,7 +869,7 @@ public class ParticipantServiceImplTest {
 
       verify(meetingService, times(1)).getMeetingEntity(meeting1Id);
       verifyNoMoreInteractions(meetingService);
-      verify(roomService, times(1)).getRoomEntityAndCheckUser(roomId, user, true);
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, user, true);
       verifyNoInteractions(participantRepository, eventDispatcher, videoServerService);
     }
   }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/PreviewServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/PreviewServiceImplTest.java
@@ -85,7 +85,7 @@ class PreviewServiceImplTest {
 
   @Test
   @DisplayName("Returns the preview of an image")
-  public void getImagePreview() throws IOException {
+  void getImagePreview() throws IOException {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
     FileMetadata expectedMetadata =
@@ -131,13 +131,13 @@ class PreviewServiceImplTest {
     verify(previewClient, times(1)).getPreviewOfImage(parametersCapture.capture());
     assertEquals(parametersCapture.getValue().toString(), parameters.toString());
     assertEquals("image", new String(previewImageResponse.getContent().readAllBytes()));
-    assertEquals(previewImageResponse.getLength(), 5);
-    assertEquals(previewImageResponse.getMimeType(), "image/jpeg");
+    assertEquals(5, previewImageResponse.getLength());
+    assertEquals("image/jpeg", previewImageResponse.getMimeType());
   }
 
   @Test
   @DisplayName("Returns the thumbnail of an image")
-  public void getImageThumbnail() throws IOException {
+  void getImageThumbnail() throws IOException {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
     FileMetadata expectedMetadata =
@@ -183,13 +183,13 @@ class PreviewServiceImplTest {
     verify(previewClient, times(1)).getThumbnailOfImage(parametersCapture.capture());
     assertEquals(parametersCapture.getValue().toString(), parameters.toString());
     assertEquals("image", new String(previewImageResponse.getContent().readAllBytes()));
-    assertEquals(previewImageResponse.getLength(), 5);
-    assertEquals(previewImageResponse.getMimeType(), "image/jpeg");
+    assertEquals(5, previewImageResponse.getLength());
+    assertEquals("image/jpeg", previewImageResponse.getMimeType());
   }
 
   @Test
   @DisplayName("Returns the preview of a pdf")
-  public void getPDFPreview() throws IOException {
+  void getPDFPreview() throws IOException {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
     FileMetadata expectedMetadata =
@@ -225,13 +225,13 @@ class PreviewServiceImplTest {
     verify(previewClient, times(1)).getPreviewOfPdf(parametersCapture.capture());
     assertEquals(parametersCapture.getValue().toString(), parameters.toString());
     assertEquals("pdf", new String(previewImageResponse.getContent().readAllBytes()));
-    assertEquals(previewImageResponse.getLength(), 3);
-    assertEquals(previewImageResponse.getMimeType(), "application/pdf");
+    assertEquals(3, previewImageResponse.getLength());
+    assertEquals("application/pdf", previewImageResponse.getMimeType());
   }
 
   @Test
   @DisplayName("Returns the thumbnail of a pdf")
-  public void getPDFThumbnail() throws IOException {
+  void getPDFThumbnail() throws IOException {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
     FileMetadata expectedMetadata =
@@ -277,13 +277,13 @@ class PreviewServiceImplTest {
     verify(previewClient, times(1)).getThumbnailOfPdf(parametersCapture.capture());
     assertEquals(parametersCapture.getValue().toString(), parameters.toString());
     assertEquals("pdf", new String(previewImageResponse.getContent().readAllBytes()));
-    assertEquals(previewImageResponse.getLength(), 3);
-    assertEquals(previewImageResponse.getMimeType(), "application/pdf");
+    assertEquals(3, previewImageResponse.getLength());
+    assertEquals("application/pdf", previewImageResponse.getMimeType());
   }
 
   @Test
   @DisplayName("Returns error if user is not in the room")
-  public void getImagePreviewNotAuthorized() {
+  void getImagePreviewNotAuthorized() {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
     FileMetadata expectedMetadata =
@@ -314,7 +314,7 @@ class PreviewServiceImplTest {
 
   @Test
   @DisplayName("Returns error if preview returns an error")
-  public void getImagePreviewPreviewException() {
+  void getImagePreviewPreviewException() {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
     FileMetadata expectedMetadata =

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/PreviewServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/PreviewServiceImplTest.java
@@ -51,22 +51,20 @@ import org.mockito.ArgumentCaptor;
 @UnitTest
 class PreviewServiceImplTest {
 
-  private final  RoomService            roomService;
-  private final  FileMetadataRepository fileMetadataRepository;
-  private final  PreviewClient          previewClient;
-  private final  PreviewService         previewService;
-  private static Room                   room1;
-  private static UUID                   user1Id;
-  private static UUID                   user2Id;
+  private final RoomService roomService;
+  private final FileMetadataRepository fileMetadataRepository;
+  private final PreviewClient previewClient;
+  private final PreviewService previewService;
+  private static Room room1;
+  private static UUID user1Id;
+  private static UUID user2Id;
 
   public PreviewServiceImplTest() {
     this.roomService = mock(RoomService.class);
     this.fileMetadataRepository = mock(FileMetadataRepository.class);
     this.previewClient = mock(PreviewClient.class);
-    this.previewService = new PreviewServiceImpl(
-      roomService,
-      fileMetadataRepository,
-      previewClient);
+    this.previewService =
+        new PreviewServiceImpl(roomService, fileMetadataRepository, previewClient);
   }
 
   @BeforeAll
@@ -75,14 +73,14 @@ class PreviewServiceImplTest {
     user2Id = UUID.randomUUID();
     room1 = Room.create();
     room1
-      .id(UUID.randomUUID().toString())
-      .type(RoomTypeDto.GROUP)
-      .name("room1")
-      .description("Room one")
-      .subscriptions(List.of(
-        Subscription.create(room1, user1Id.toString()).owner(true),
-        Subscription.create(room1, user2Id.toString()).owner(false))
-      );
+        .id(UUID.randomUUID().toString())
+        .type(RoomTypeDto.GROUP)
+        .name("room1")
+        .description("Room one")
+        .subscriptions(
+            List.of(
+                Subscription.create(room1, user1Id.toString()).owner(true),
+                Subscription.create(room1, user2Id.toString()).owner(false)));
   }
 
   @Test
@@ -90,33 +88,45 @@ class PreviewServiceImplTest {
   public void getImagePreview() throws IOException {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
-    FileMetadata expectedMetadata = FileMetadataBuilder.create().id(fileId.toString())
-      .name("snoopy.jpg").mimeType("image/jpeg").type(FileMetadataType.ATTACHMENT)
-      .userId(user1Id.toString()).roomId(room1.getId()).build();
-    when(fileMetadataRepository.getById(fileId.toString())).thenReturn(Optional.of(expectedMetadata));
-    when(roomService.getRoomEntityAndCheckUser(UUID.fromString(room1.getId()), currentUser, false)).thenReturn(room1);
-    Query parameters = new Query.QueryBuilder()
-      .setFileOwnerId(user1Id.toString())
-      .setServiceType(ServiceType.CHATS)
-      .setFileId(fileId.toString())
-      .setVersion(0)
-      .setPreviewArea("100x100")
-      .setQuality(Quality.HIGH)
-      .setOutputFormat(Format.JPEG)
-      .setCrop(false)
-      .build();
+    FileMetadata expectedMetadata =
+        FileMetadataBuilder.create()
+            .id(fileId.toString())
+            .name("snoopy.jpg")
+            .mimeType("image/jpeg")
+            .type(FileMetadataType.ATTACHMENT)
+            .userId(user1Id.toString())
+            .roomId(room1.getId())
+            .build();
+    when(fileMetadataRepository.getById(fileId.toString()))
+        .thenReturn(Optional.of(expectedMetadata));
+    when(roomService.getRoomAndValidateUser(UUID.fromString(room1.getId()), currentUser, false))
+        .thenReturn(room1);
+    Query parameters =
+        new Query.QueryBuilder()
+            .setFileOwnerId(user1Id.toString())
+            .setServiceType(ServiceType.CHATS)
+            .setFileId(fileId.toString())
+            .setVersion(0)
+            .setPreviewArea("100x100")
+            .setQuality(Quality.HIGH)
+            .setOutputFormat(Format.JPEG)
+            .setCrop(false)
+            .build();
     BlobResponse mockBlobResponse = mock(BlobResponse.class);
     when(mockBlobResponse.getContent()).thenReturn(new ByteArrayInputStream("image".getBytes()));
     when(mockBlobResponse.getLength()).thenReturn(5L);
     when(mockBlobResponse.getMimeType()).thenReturn("image/jpeg");
     ArgumentCaptor<Query> parametersCapture = ArgumentCaptor.forClass(Query.class);
-    when(previewClient.getPreviewOfImage(any(Query.class))).thenReturn(Try.success(mockBlobResponse));
-    FileResponse previewImageResponse = previewService.getImage(currentUser,
-      fileId,
-      "100x100",
-      Option.of(ImageQualityEnumDto.HIGH),
-      Option.of(ImageTypeEnumDto.JPEG),
-      Option.of(false));
+    when(previewClient.getPreviewOfImage(any(Query.class)))
+        .thenReturn(Try.success(mockBlobResponse));
+    FileResponse previewImageResponse =
+        previewService.getImage(
+            currentUser,
+            fileId,
+            "100x100",
+            Option.of(ImageQualityEnumDto.HIGH),
+            Option.of(ImageTypeEnumDto.JPEG),
+            Option.of(false));
 
     verify(previewClient, times(1)).getPreviewOfImage(parametersCapture.capture());
     assertEquals(parametersCapture.getValue().toString(), parameters.toString());
@@ -130,33 +140,45 @@ class PreviewServiceImplTest {
   public void getImageThumbnail() throws IOException {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
-    FileMetadata expectedMetadata = FileMetadataBuilder.create().id(fileId.toString())
-      .name("snoopy.jpg").mimeType("image/jpeg").type(FileMetadataType.ATTACHMENT)
-      .userId(user1Id.toString()).roomId(room1.getId()).build();
-    when(fileMetadataRepository.getById(fileId.toString())).thenReturn(Optional.of(expectedMetadata));
-    when(roomService.getRoomEntityAndCheckUser(UUID.fromString(room1.getId()), currentUser, false)).thenReturn(room1);
-    Query parameters = new Query.QueryBuilder()
-      .setFileOwnerId(user1Id.toString())
-      .setServiceType(ServiceType.CHATS)
-      .setFileId(fileId.toString())
-      .setVersion(0)
-      .setPreviewArea("100x100")
-      .setQuality(Quality.HIGH)
-      .setOutputFormat(Format.JPEG)
-      .setShape(Shape.RECTANGULAR)
-      .build();
+    FileMetadata expectedMetadata =
+        FileMetadataBuilder.create()
+            .id(fileId.toString())
+            .name("snoopy.jpg")
+            .mimeType("image/jpeg")
+            .type(FileMetadataType.ATTACHMENT)
+            .userId(user1Id.toString())
+            .roomId(room1.getId())
+            .build();
+    when(fileMetadataRepository.getById(fileId.toString()))
+        .thenReturn(Optional.of(expectedMetadata));
+    when(roomService.getRoomAndValidateUser(UUID.fromString(room1.getId()), currentUser, false))
+        .thenReturn(room1);
+    Query parameters =
+        new Query.QueryBuilder()
+            .setFileOwnerId(user1Id.toString())
+            .setServiceType(ServiceType.CHATS)
+            .setFileId(fileId.toString())
+            .setVersion(0)
+            .setPreviewArea("100x100")
+            .setQuality(Quality.HIGH)
+            .setOutputFormat(Format.JPEG)
+            .setShape(Shape.RECTANGULAR)
+            .build();
     BlobResponse mockBlobResponse = mock(BlobResponse.class);
     when(mockBlobResponse.getContent()).thenReturn(new ByteArrayInputStream("image".getBytes()));
     when(mockBlobResponse.getLength()).thenReturn(5L);
     when(mockBlobResponse.getMimeType()).thenReturn("image/jpeg");
     ArgumentCaptor<Query> parametersCapture = ArgumentCaptor.forClass(Query.class);
-    when(previewClient.getThumbnailOfImage(any(Query.class))).thenReturn(Try.success(mockBlobResponse));
-    FileResponse previewImageResponse = previewService.getImageThumbnail(currentUser,
-      fileId,
-      "100x100",
-      Option.of(ImageQualityEnumDto.HIGH),
-      Option.of(ImageTypeEnumDto.JPEG),
-      Option.of(ImageShapeEnumDto.RECTANGULAR));
+    when(previewClient.getThumbnailOfImage(any(Query.class)))
+        .thenReturn(Try.success(mockBlobResponse));
+    FileResponse previewImageResponse =
+        previewService.getImageThumbnail(
+            currentUser,
+            fileId,
+            "100x100",
+            Option.of(ImageQualityEnumDto.HIGH),
+            Option.of(ImageTypeEnumDto.JPEG),
+            Option.of(ImageShapeEnumDto.RECTANGULAR));
 
     verify(previewClient, times(1)).getThumbnailOfImage(parametersCapture.capture());
     assertEquals(parametersCapture.getValue().toString(), parameters.toString());
@@ -170,29 +192,35 @@ class PreviewServiceImplTest {
   public void getPDFPreview() throws IOException {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
-    FileMetadata expectedMetadata = FileMetadataBuilder.create().id(fileId.toString())
-      .name("test.pdf").mimeType("application/pdf").type(FileMetadataType.ATTACHMENT)
-      .userId(user1Id.toString()).roomId(room1.getId()).build();
-    when(fileMetadataRepository.getById(fileId.toString())).thenReturn(Optional.of(expectedMetadata));
-    when(roomService.getRoomEntityAndCheckUser(UUID.fromString(room1.getId()), currentUser, false)).thenReturn(room1);
-    Query parameters = new Query.QueryBuilder()
-      .setFileOwnerId(user1Id.toString())
-      .setServiceType(ServiceType.CHATS)
-      .setFileId(fileId.toString())
-      .setVersion(0)
-      .setFirstPage(1)
-      .setLastPage(0)
-      .build();
+    FileMetadata expectedMetadata =
+        FileMetadataBuilder.create()
+            .id(fileId.toString())
+            .name("test.pdf")
+            .mimeType("application/pdf")
+            .type(FileMetadataType.ATTACHMENT)
+            .userId(user1Id.toString())
+            .roomId(room1.getId())
+            .build();
+    when(fileMetadataRepository.getById(fileId.toString()))
+        .thenReturn(Optional.of(expectedMetadata));
+    when(roomService.getRoomAndValidateUser(UUID.fromString(room1.getId()), currentUser, false))
+        .thenReturn(room1);
+    Query parameters =
+        new Query.QueryBuilder()
+            .setFileOwnerId(user1Id.toString())
+            .setServiceType(ServiceType.CHATS)
+            .setFileId(fileId.toString())
+            .setVersion(0)
+            .setFirstPage(1)
+            .setLastPage(0)
+            .build();
     BlobResponse mockBlobResponse = mock(BlobResponse.class);
     when(mockBlobResponse.getContent()).thenReturn(new ByteArrayInputStream("pdf".getBytes()));
     when(mockBlobResponse.getLength()).thenReturn(3L);
     when(mockBlobResponse.getMimeType()).thenReturn("application/pdf");
     ArgumentCaptor<Query> parametersCapture = ArgumentCaptor.forClass(Query.class);
     when(previewClient.getPreviewOfPdf(any(Query.class))).thenReturn(Try.success(mockBlobResponse));
-    FileResponse previewImageResponse = previewService.getPDF(currentUser,
-      fileId,
-      1,
-      0);
+    FileResponse previewImageResponse = previewService.getPDF(currentUser, fileId, 1, 0);
 
     verify(previewClient, times(1)).getPreviewOfPdf(parametersCapture.capture());
     assertEquals(parametersCapture.getValue().toString(), parameters.toString());
@@ -206,33 +234,45 @@ class PreviewServiceImplTest {
   public void getPDFThumbnail() throws IOException {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
-    FileMetadata expectedMetadata = FileMetadataBuilder.create().id(fileId.toString())
-      .name("test.pdf").mimeType("application/pdf").type(FileMetadataType.ATTACHMENT)
-      .userId(user1Id.toString()).roomId(room1.getId()).build();
-    when(fileMetadataRepository.getById(fileId.toString())).thenReturn(Optional.of(expectedMetadata));
-    when(roomService.getRoomEntityAndCheckUser(UUID.fromString(room1.getId()), currentUser, false)).thenReturn(room1);
-    Query parameters = new Query.QueryBuilder()
-      .setFileOwnerId(user1Id.toString())
-      .setServiceType(ServiceType.CHATS)
-      .setFileId(fileId.toString())
-      .setVersion(0)
-      .setPreviewArea("100x100")
-      .setQuality(Quality.HIGH)
-      .setOutputFormat(Format.JPEG)
-      .setShape(Shape.RECTANGULAR)
-      .build();
+    FileMetadata expectedMetadata =
+        FileMetadataBuilder.create()
+            .id(fileId.toString())
+            .name("test.pdf")
+            .mimeType("application/pdf")
+            .type(FileMetadataType.ATTACHMENT)
+            .userId(user1Id.toString())
+            .roomId(room1.getId())
+            .build();
+    when(fileMetadataRepository.getById(fileId.toString()))
+        .thenReturn(Optional.of(expectedMetadata));
+    when(roomService.getRoomAndValidateUser(UUID.fromString(room1.getId()), currentUser, false))
+        .thenReturn(room1);
+    Query parameters =
+        new Query.QueryBuilder()
+            .setFileOwnerId(user1Id.toString())
+            .setServiceType(ServiceType.CHATS)
+            .setFileId(fileId.toString())
+            .setVersion(0)
+            .setPreviewArea("100x100")
+            .setQuality(Quality.HIGH)
+            .setOutputFormat(Format.JPEG)
+            .setShape(Shape.RECTANGULAR)
+            .build();
     BlobResponse mockBlobResponse = mock(BlobResponse.class);
     when(mockBlobResponse.getContent()).thenReturn(new ByteArrayInputStream("pdf".getBytes()));
     when(mockBlobResponse.getLength()).thenReturn(3L);
     when(mockBlobResponse.getMimeType()).thenReturn("application/pdf");
     ArgumentCaptor<Query> parametersCapture = ArgumentCaptor.forClass(Query.class);
-    when(previewClient.getThumbnailOfPdf(any(Query.class))).thenReturn(Try.success(mockBlobResponse));
-    FileResponse previewImageResponse = previewService.getPDFThumbnail(currentUser,
-      fileId,
-      "100x100",
-      Option.of(ImageQualityEnumDto.HIGH),
-      Option.of(ImageTypeEnumDto.JPEG),
-      Option.of(ImageShapeEnumDto.RECTANGULAR));
+    when(previewClient.getThumbnailOfPdf(any(Query.class)))
+        .thenReturn(Try.success(mockBlobResponse));
+    FileResponse previewImageResponse =
+        previewService.getPDFThumbnail(
+            currentUser,
+            fileId,
+            "100x100",
+            Option.of(ImageQualityEnumDto.HIGH),
+            Option.of(ImageTypeEnumDto.JPEG),
+            Option.of(ImageShapeEnumDto.RECTANGULAR));
 
     verify(previewClient, times(1)).getThumbnailOfPdf(parametersCapture.capture());
     assertEquals(parametersCapture.getValue().toString(), parameters.toString());
@@ -246,19 +286,30 @@ class PreviewServiceImplTest {
   public void getImagePreviewNotAuthorized() {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
-    FileMetadata expectedMetadata = FileMetadataBuilder.create().id(fileId.toString())
-      .name("snoopy.jpg").mimeType("image/jpeg").type(FileMetadataType.ATTACHMENT)
-      .userId(user1Id.toString()).roomId(room1.getId()).build();
-    when(fileMetadataRepository.getById(fileId.toString())).thenReturn(Optional.of(expectedMetadata));
-    when(roomService.getRoomEntityAndCheckUser(UUID.fromString(room1.getId()), currentUser, false))
-      .thenThrow(new ForbiddenException());
+    FileMetadata expectedMetadata =
+        FileMetadataBuilder.create()
+            .id(fileId.toString())
+            .name("snoopy.jpg")
+            .mimeType("image/jpeg")
+            .type(FileMetadataType.ATTACHMENT)
+            .userId(user1Id.toString())
+            .roomId(room1.getId())
+            .build();
+    when(fileMetadataRepository.getById(fileId.toString()))
+        .thenReturn(Optional.of(expectedMetadata));
+    when(roomService.getRoomAndValidateUser(UUID.fromString(room1.getId()), currentUser, false))
+        .thenThrow(new ForbiddenException());
 
-    assertThrows(ForbiddenException.class, () -> previewService.getImage(currentUser,
-      fileId,
-      "100x100",
-      Option.of(ImageQualityEnumDto.HIGH),
-      Option.of(ImageTypeEnumDto.JPEG),
-      Option.of(false)));
+    assertThrows(
+        ForbiddenException.class,
+        () ->
+            previewService.getImage(
+                currentUser,
+                fileId,
+                "100x100",
+                Option.of(ImageQualityEnumDto.HIGH),
+                Option.of(ImageTypeEnumDto.JPEG),
+                Option.of(false)));
   }
 
   @Test
@@ -266,18 +317,30 @@ class PreviewServiceImplTest {
   public void getImagePreviewPreviewException() {
     UUID fileId = UUID.randomUUID();
     UserPrincipal currentUser = UserPrincipal.create(user1Id);
-    FileMetadata expectedMetadata = FileMetadataBuilder.create().id(fileId.toString())
-      .name("snoopy.jpg").mimeType("image/jpeg").type(FileMetadataType.ATTACHMENT)
-      .userId(user1Id.toString()).roomId(room1.getId()).build();
-    when(fileMetadataRepository.getById(fileId.toString())).thenReturn(Optional.of(expectedMetadata));
-    when(roomService.getRoomEntityAndCheckUser(UUID.fromString(room1.getId()), currentUser, false))
-      .thenReturn(room1);
-    when(previewClient.getPreviewOfImage(any(Query.class))).thenReturn(Try.failure(new RuntimeException()));
-    assertThrows(PreviewException.class, () -> previewService.getImage(currentUser,
-      fileId,
-      "100x100",
-      Option.of(ImageQualityEnumDto.HIGH),
-      Option.of(ImageTypeEnumDto.JPEG),
-      Option.of(false)));
+    FileMetadata expectedMetadata =
+        FileMetadataBuilder.create()
+            .id(fileId.toString())
+            .name("snoopy.jpg")
+            .mimeType("image/jpeg")
+            .type(FileMetadataType.ATTACHMENT)
+            .userId(user1Id.toString())
+            .roomId(room1.getId())
+            .build();
+    when(fileMetadataRepository.getById(fileId.toString()))
+        .thenReturn(Optional.of(expectedMetadata));
+    when(roomService.getRoomAndValidateUser(UUID.fromString(room1.getId()), currentUser, false))
+        .thenReturn(room1);
+    when(previewClient.getPreviewOfImage(any(Query.class)))
+        .thenReturn(Try.failure(new RuntimeException()));
+    assertThrows(
+        PreviewException.class,
+        () ->
+            previewService.getImage(
+                currentUser,
+                fileId,
+                "100x100",
+                Option.of(ImageQualityEnumDto.HIGH),
+                Option.of(ImageTypeEnumDto.JPEG),
+                Option.of(false)));
   }
 }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/RoomServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/RoomServiceImplTest.java
@@ -655,7 +655,7 @@ class RoomServiceImplTest {
                 () -> roomService.createRoom(creationFields, mockUserPrincipal));
         assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
         assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
-        assertEquals("Bad Request - Too few members (required at least 3)", exception.getMessage());
+        assertEquals("Bad Request - Too few members (required at least 2)", exception.getMessage());
       }
 
       @Test
@@ -685,7 +685,7 @@ class RoomServiceImplTest {
         assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
         assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
         assertEquals(
-            "Bad Request - Too much members (required less than 3)", exception.getMessage());
+            "Bad Request - Too many members (required less than 2)", exception.getMessage());
       }
 
       @Test
@@ -889,7 +889,7 @@ class RoomServiceImplTest {
     class CreateOneToOneRoomTests {
 
       @Test
-      @DisplayName("It creates a one to one room and returns it")
+      @DisplayName("It creates a one-to-one room and returns it")
       void createRoomOneToOne_testOk() {
         UserPrincipal mockUserPrincipal = UserPrincipal.create(user1Id);
         when(userService.userExists(user2Id, mockUserPrincipal)).thenReturn(true);
@@ -948,7 +948,7 @@ class RoomServiceImplTest {
 
       @Test
       @DisplayName(
-          "There are less than two members when creating a one to one, it throws a 'bad request'"
+          "There are less than two members when creating a one-to-one, it throws a 'bad request'"
               + " exception")
       void createRoomOneToOne_errorWhenMembersAreLessThanTwo() {
         RoomCreationFieldsDto creationFields =
@@ -964,13 +964,13 @@ class RoomServiceImplTest {
         assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
         assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
         assertEquals(
-            "Bad Request - Only 2 users can participate to a one-to-one room",
+            "Bad Request - Only 2 users can participate in a one-to-one room",
             exception.getMessage());
       }
 
       @Test
       @DisplayName(
-          "There are more than two members when creating a one to one with the requester in it, it"
+          "There are more than two members when creating a one-to-one with the requester in it, it"
               + " throws a 'bad request' exception")
       void createRoomOneToOne_errorWhenMembersAreMoreThanTwo() {
         RoomCreationFieldsDto creationFields =
@@ -988,13 +988,13 @@ class RoomServiceImplTest {
         assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
         assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
         assertEquals(
-            "Bad Request - Only 2 users can participate to a one-to-one room",
+            "Bad Request - Only 2 users can participate in a one-to-one room",
             exception.getMessage());
       }
 
       @Test
       @DisplayName(
-          "Given creation fields for a one to one room, if there is a room with those users returns"
+          "Given creation fields for a one-to-one room, if there is a room with those users returns"
               + " a status code 409")
       void createRoomOneToOne_testOneToOneAlreadyExists() {
         UserPrincipal mockUserPrincipal = UserPrincipal.create(user1Id);
@@ -1014,7 +1014,7 @@ class RoomServiceImplTest {
         assertEquals(Status.CONFLICT.getStatusCode(), exception.getHttpStatusCode());
         assertEquals(Status.CONFLICT.getReasonPhrase(), exception.getHttpStatusPhrase());
         assertEquals(
-            "Conflict - The one to one room already exists for these users",
+            "Conflict - The one-to-one room already exists for these users",
             exception.getMessage());
       }
     }
@@ -1658,7 +1658,7 @@ class RoomServiceImplTest {
     void getRoomAndCheckUser_testOk() {
       when(roomRepository.getById(roomGroup1Id.toString())).thenReturn(Optional.of(roomGroup1));
       Room room =
-          roomService.getRoomEntityAndCheckUser(roomGroup1Id, UserPrincipal.create(user1Id), false);
+          roomService.getRoomAndValidateUser(roomGroup1Id, UserPrincipal.create(user1Id), false);
 
       assertEquals(roomGroup1, room);
       verify(roomRepository, times(1)).getById(roomGroup1Id.toString());
@@ -1674,7 +1674,7 @@ class RoomServiceImplTest {
           assertThrows(
               ForbiddenException.class,
               () ->
-                  roomService.getRoomEntityAndCheckUser(
+                  roomService.getRoomAndValidateUser(
                       roomGroup2Id, UserPrincipal.create(user1Id), false));
 
       assertEquals(Status.FORBIDDEN.getStatusCode(), exception.getHttpStatusCode());
@@ -1694,7 +1694,7 @@ class RoomServiceImplTest {
           assertThrows(
               ForbiddenException.class,
               () ->
-                  roomService.getRoomEntityAndCheckUser(
+                  roomService.getRoomAndValidateUser(
                       roomGroup1Id, UserPrincipal.create(user2Id), true));
 
       assertEquals(Status.FORBIDDEN.getStatusCode(), exception.getHttpStatusCode());

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/RoomServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/RoomServiceImplTest.java
@@ -110,34 +110,34 @@ class RoomServiceImplTest {
 
   public RoomServiceImplTest(RoomMapper roomMapper) {
     this.roomRepository = mock(RoomRepository.class);
-    this.attachmentService = mock(AttachmentService.class);
     this.roomUserSettingsRepository = mock(RoomUserSettingsRepository.class);
+    this.fileMetadataRepository = mock(FileMetadataRepository.class);
     this.userService = mock(UserService.class);
     this.membersService = mock(MembersService.class);
+    this.meetingService = mock(MeetingService.class);
+    this.storagesService = mock(StoragesService.class);
+    this.attachmentService = mock(AttachmentService.class);
+    this.capabilityService = mock(CapabilityService.class);
     this.eventDispatcher = mock(EventDispatcher.class);
     this.messageDispatcher = mock(MessageDispatcher.class);
-    this.meetingService = mock(MeetingService.class);
-    this.fileMetadataRepository = mock(FileMetadataRepository.class);
-    this.storagesService = mock(StoragesService.class);
     this.clock = mock(Clock.class);
     this.appConfig = mock(AppConfig.class);
-    this.capabilityService = mock(CapabilityService.class);
     this.roomService =
         new RoomServiceImpl(
             this.roomRepository,
             this.roomUserSettingsRepository,
-            roomMapper,
-            this.eventDispatcher,
-            this.messageDispatcher,
+            this.fileMetadataRepository,
             this.userService,
             this.membersService,
             this.meetingService,
-            this.fileMetadataRepository,
             this.storagesService,
             this.attachmentService,
+            this.capabilityService,
+            this.eventDispatcher,
+            this.messageDispatcher,
+            roomMapper,
             this.clock,
-            this.appConfig,
-            this.capabilityService);
+            this.appConfig);
   }
 
   private UUID user1Id;
@@ -147,11 +147,15 @@ class RoomServiceImplTest {
   private UUID user5Id;
   private UUID roomGroup1Id;
   private UUID roomGroup2Id;
+  private UUID roomTemporary1Id;
+  private UUID roomTemporary2Id;
   private UUID roomOneToOne1Id;
   private UUID roomOneToOne2Id;
 
   private Room roomGroup1;
   private Room roomGroup2;
+  private Room roomTemporary1;
+  private Room roomTemporary2;
   private Room roomOneToOne1;
   private Room roomOneToOne2;
 
@@ -168,6 +172,8 @@ class RoomServiceImplTest {
 
     roomGroup1Id = UUID.fromString("cdc44826-23b0-4e99-bec2-7fb2f00b6b13");
     roomGroup2Id = UUID.fromString("0471809c-e0bb-4bfd-85b6-b7b9a1eca597");
+    roomTemporary1Id = UUID.fromString("823379f7-4cd6-4513-85fe-66494a233e1f");
+    roomTemporary2Id = UUID.fromString("ebbd8c5f-12f3-413d-92f5-6da1cdb8c644");
     roomOneToOne1Id = UUID.fromString("86327874-40f4-47cb-914d-f0ce706d1611");
     roomOneToOne2Id = UUID.fromString("19e5717e-652d-409e-b4fa-87e8dff790c1");
 
@@ -194,6 +200,27 @@ class RoomServiceImplTest {
             List.of(
                 Subscription.create(roomGroup2, user2Id.toString()).owner(true),
                 Subscription.create(roomGroup2, user3Id.toString()).owner(false)));
+
+    roomTemporary1 = Room.create();
+    roomTemporary1
+        .id(roomTemporary1Id.toString())
+        .type(RoomTypeDto.TEMPORARY)
+        .name("temporary1")
+        .description("")
+        .subscriptions(
+            List.of(Subscription.create(roomTemporary1, user1Id.toString()).owner(true)));
+
+    roomTemporary2 = Room.create();
+    roomTemporary2
+        .id(roomTemporary2Id.toString())
+        .type(RoomTypeDto.TEMPORARY)
+        .name("temporary2")
+        .description("")
+        .subscriptions(
+            List.of(
+                Subscription.create(roomTemporary2, user1Id.toString()).owner(true),
+                Subscription.create(roomTemporary2, user2Id.toString()).owner(true),
+                Subscription.create(roomTemporary2, user3Id.toString())));
 
     roomOneToOne1 = Room.create();
     roomOneToOne1
@@ -514,7 +541,11 @@ class RoomServiceImplTest {
                 List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
                 RoomCreated.create().roomId(roomGroup1Id));
         verifyNoMoreInteractions(eventDispatcher);
-        verify(messageDispatcher, times(1)).createRoom(roomGroup1, user1Id.toString());
+        verify(messageDispatcher, times(1))
+            .createRoom(
+                roomGroup1Id.toString(),
+                user1Id.toString(),
+                List.of(user2Id.toString(), user3Id.toString()));
         verify(messageDispatcher, times(0)).addUsersToContacts(anyString(), anyString());
         verifyNoMoreInteractions(messageDispatcher);
       }
@@ -594,7 +625,11 @@ class RoomServiceImplTest {
                 List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
                 RoomCreated.create().roomId(roomGroup1Id));
         verifyNoMoreInteractions(eventDispatcher);
-        verify(messageDispatcher, times(1)).createRoom(roomGroup1, user1Id.toString());
+        verify(messageDispatcher, times(1))
+            .createRoom(
+                roomGroup1Id.toString(),
+                user1Id.toString(),
+                List.of(user2Id.toString(), user3Id.toString()));
         verify(messageDispatcher, times(0)).addUsersToContacts(anyString(), anyString());
         verifyNoMoreInteractions(messageDispatcher);
       }
@@ -652,6 +687,201 @@ class RoomServiceImplTest {
         assertEquals(
             "Bad Request - Too much members (required less than 3)", exception.getMessage());
       }
+
+      @Test
+      @DisplayName("If there are duplicate invites, it throws a 'bad request' exception")
+      void createGroupRoom_testRoomToCreateWithDuplicateInvites() {
+        RoomCreationFieldsDto creationFields =
+            RoomCreationFieldsDto.create()
+                .name("room1")
+                .description("Room one")
+                .type(RoomTypeDto.GROUP)
+                .members(
+                    List.of(
+                        MemberDto.create().userId(user2Id), MemberDto.create().userId(user2Id)));
+        ChatsHttpException exception =
+            assertThrows(
+                BadRequestException.class,
+                () -> roomService.createRoom(creationFields, UserPrincipal.create(user1Id)));
+        assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
+        assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
+        assertEquals("Bad Request - Members cannot be duplicated", exception.getMessage());
+      }
+
+      @Test
+      @DisplayName("If the current user is invited, it throws a 'bad request' exception")
+      void createGroupRoom_testRoomToCreateWithInvitedUsersListContainsCurrentUser() {
+        RoomCreationFieldsDto creationFields =
+            RoomCreationFieldsDto.create()
+                .name("room1")
+                .description("Room one")
+                .type(RoomTypeDto.GROUP)
+                .members(
+                    List.of(
+                        MemberDto.create().userId(user1Id), MemberDto.create().userId(user2Id)));
+        ChatsHttpException exception =
+            assertThrows(
+                BadRequestException.class,
+                () -> roomService.createRoom(creationFields, UserPrincipal.create(user1Id)));
+        assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
+        assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
+        assertEquals(
+            "Bad Request - Requester can't be invited to the room", exception.getMessage());
+      }
+
+      @Test
+      @DisplayName("If there is an invitee without account, it throws a 'not found' exception")
+      void createGroupRoom_testInvitedUserWithoutAccount() {
+        UserPrincipal mockUserPrincipal = UserPrincipal.create(user1Id);
+        when(userService.userExists(user3Id, mockUserPrincipal)).thenReturn(true);
+        when(userService.userExists(user2Id, mockUserPrincipal)).thenReturn(false);
+        when(capabilityService.getCapabilities(mockUserPrincipal))
+            .thenReturn(CapabilitiesDto.create().maxGroupMembers(128));
+
+        RoomCreationFieldsDto creationFields =
+            RoomCreationFieldsDto.create()
+                .name("room1")
+                .description("Room one")
+                .type(RoomTypeDto.GROUP)
+                .members(
+                    List.of(
+                        MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id)));
+        ChatsHttpException exception =
+            assertThrows(
+                NotFoundException.class,
+                () -> roomService.createRoom(creationFields, mockUserPrincipal));
+        assertEquals(Status.NOT_FOUND.getStatusCode(), exception.getHttpStatusCode());
+        assertEquals(Status.NOT_FOUND.getReasonPhrase(), exception.getHttpStatusPhrase());
+        assertEquals(
+            String.format("Not Found - User with id '%s' not found", user2Id),
+            exception.getMessage());
+      }
+    }
+
+    @Nested
+    @DisplayName("Create temporary room tests")
+    class CreateTemporaryRoomTests {
+
+      @Test
+      @DisplayName("It creates the room and returns it")
+      void createTemporaryRoom_testOk() {
+        UserPrincipal mockUserPrincipal = UserPrincipal.create(user1Id).queueId(UUID.randomUUID());
+        when(userService.userExists(user2Id, mockUserPrincipal)).thenReturn(true);
+        when(userService.userExists(user3Id, mockUserPrincipal)).thenReturn(true);
+        when(membersService.initRoomSubscriptions(
+                eq(List.of(MemberDto.create().userId(user1Id).owner(true))), any(Room.class)))
+            .thenReturn(
+                List.of(Subscription.create(roomTemporary1, user1Id.toString()).owner(true)));
+        when(roomRepository.insert(roomTemporary1)).thenReturn(roomTemporary1);
+
+        RoomCreationFieldsDto creationFields =
+            RoomCreationFieldsDto.create()
+                .name("temporary1")
+                .description("")
+                .type(RoomTypeDto.TEMPORARY);
+        RoomDto room;
+        try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
+          uuid.when(UUID::randomUUID).thenReturn(roomTemporary1Id);
+          uuid.when(() -> UUID.fromString(roomTemporary1.getId())).thenReturn(roomTemporary1Id);
+          uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
+          room = roomService.createRoom(creationFields, mockUserPrincipal);
+        }
+        assertEquals(creationFields.getName(), room.getName());
+        assertEquals(creationFields.getDescription(), room.getDescription());
+        assertEquals(creationFields.getType(), room.getType());
+        assertEquals(1, room.getMembers().size());
+
+        Optional<MemberDto> user1 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user1Id))
+                .findFirst();
+        assertTrue(user1.isPresent());
+        assertTrue(user1.get().isOwner());
+
+        verify(eventDispatcher, times(1))
+            .sendToUserExchange(
+                List.of(user1Id.toString()), RoomCreated.create().roomId(roomTemporary1Id));
+        verifyNoMoreInteractions(eventDispatcher);
+        verify(messageDispatcher, times(1))
+            .createRoom(roomTemporary1Id.toString(), user1Id.toString(), List.of());
+        verify(messageDispatcher, times(0)).addUsersToContacts(anyString(), anyString());
+        verifyNoMoreInteractions(messageDispatcher);
+      }
+
+      @Test
+      @DisplayName("It creates the room setting the owners and returns it")
+      void createTemporaryRoom_testOkWithOwners() {
+        UserPrincipal mockUserPrincipal = UserPrincipal.create(user1Id).queueId(UUID.randomUUID());
+        when(userService.userExists(user2Id, mockUserPrincipal)).thenReturn(true);
+        when(userService.userExists(user3Id, mockUserPrincipal)).thenReturn(true);
+        when(membersService.initRoomSubscriptions(
+                eq(
+                    List.of(
+                        MemberDto.create().userId(user1Id).owner(true),
+                        MemberDto.create().userId(user2Id).owner(true),
+                        MemberDto.create().userId(user3Id))),
+                any(Room.class)))
+            .thenReturn(
+                List.of(
+                    Subscription.create(roomTemporary2, user1Id.toString()).owner(true),
+                    Subscription.create(roomTemporary2, user2Id.toString()).owner(true),
+                    Subscription.create(roomTemporary2, user3Id.toString())));
+        when(roomRepository.insert(roomTemporary2)).thenReturn(roomTemporary2);
+
+        RoomCreationFieldsDto creationFields =
+            RoomCreationFieldsDto.create()
+                .name("temporary2")
+                .description("")
+                .type(RoomTypeDto.TEMPORARY)
+                .members(
+                    List.of(
+                        MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id)));
+        RoomDto room;
+        try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
+          uuid.when(UUID::randomUUID).thenReturn(roomTemporary2Id);
+          uuid.when(() -> UUID.fromString(roomTemporary2.getId())).thenReturn(roomTemporary2Id);
+          uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
+          uuid.when(() -> UUID.fromString(user2Id.toString())).thenReturn(user2Id);
+          uuid.when(() -> UUID.fromString(user3Id.toString())).thenReturn(user3Id);
+          room = roomService.createRoom(creationFields, mockUserPrincipal);
+        }
+        assertEquals(creationFields.getName(), room.getName());
+        assertEquals(creationFields.getDescription(), room.getDescription());
+        assertEquals(creationFields.getType(), room.getType());
+        assertEquals(3, room.getMembers().size());
+
+        Optional<MemberDto> user1 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user1Id))
+                .findFirst();
+        assertTrue(user1.isPresent());
+        assertTrue(user1.get().isOwner());
+        Optional<MemberDto> user2 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user2Id))
+                .findFirst();
+        assertTrue(user2.isPresent());
+        assertTrue(user2.get().isOwner());
+        Optional<MemberDto> user3 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user3Id))
+                .findFirst();
+        assertTrue(user3.isPresent());
+        assertFalse(user3.get().isOwner());
+
+        verify(eventDispatcher, times(1))
+            .sendToUserExchange(
+                List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
+                RoomCreated.create().roomId(roomTemporary2Id));
+        verifyNoMoreInteractions(eventDispatcher);
+        verify(messageDispatcher, times(1))
+            .createRoom(
+                roomTemporary2Id.toString(),
+                user1Id.toString(),
+                List.of(user2Id.toString(), user3Id.toString()));
+        verify(messageDispatcher, times(0)).addUsersToContacts(anyString(), anyString());
+        verifyNoMoreInteractions(messageDispatcher);
+      }
     }
 
     @Nested
@@ -708,7 +938,9 @@ class RoomServiceImplTest {
                 List.of(user1Id.toString(), user2Id.toString()),
                 RoomCreated.create().roomId(roomOneToOne1Id));
         verifyNoMoreInteractions(eventDispatcher);
-        verify(messageDispatcher, times(1)).createRoom(roomOneToOne1, user1Id.toString());
+        verify(messageDispatcher, times(1))
+            .createRoom(
+                roomOneToOne1Id.toString(), user1Id.toString(), List.of(user2Id.toString()));
         verify(messageDispatcher, times(1))
             .addUsersToContacts(user1Id.toString(), user2Id.toString());
         verifyNoMoreInteractions(messageDispatcher);
@@ -785,70 +1017,6 @@ class RoomServiceImplTest {
             "Conflict - The one to one room already exists for these users",
             exception.getMessage());
       }
-    }
-
-    @Test
-    @DisplayName("If there are duplicate invites, it throws a 'bad request' exception")
-    void createRoom_testRoomToCreateWithDuplicateInvites() {
-      RoomCreationFieldsDto creationFields =
-          RoomCreationFieldsDto.create()
-              .name("room1")
-              .description("Room one")
-              .type(RoomTypeDto.GROUP)
-              .members(
-                  List.of(MemberDto.create().userId(user2Id), MemberDto.create().userId(user2Id)));
-      ChatsHttpException exception =
-          assertThrows(
-              BadRequestException.class,
-              () -> roomService.createRoom(creationFields, UserPrincipal.create(user1Id)));
-      assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
-      assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
-      assertEquals("Bad Request - Members cannot be duplicated", exception.getMessage());
-    }
-
-    @Test
-    @DisplayName("If the current user is invited, it throws a 'bad request' exception")
-    void createRoom_testRoomToCreateWithInvitedUsersListContainsCurrentUser() {
-      RoomCreationFieldsDto creationFields =
-          RoomCreationFieldsDto.create()
-              .name("room1")
-              .description("Room one")
-              .type(RoomTypeDto.GROUP)
-              .members(
-                  List.of(MemberDto.create().userId(user1Id), MemberDto.create().userId(user2Id)));
-      ChatsHttpException exception =
-          assertThrows(
-              BadRequestException.class,
-              () -> roomService.createRoom(creationFields, UserPrincipal.create(user1Id)));
-      assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
-      assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
-      assertEquals("Bad Request - Requester can't be invited to the room", exception.getMessage());
-    }
-
-    @Test
-    @DisplayName("If there is an invitee without account, it throws a 'not found' exception")
-    void createRoom_testInvitedUserWithoutAccount() {
-      UserPrincipal mockUserPrincipal = UserPrincipal.create(user1Id);
-      when(userService.userExists(user2Id, mockUserPrincipal)).thenReturn(false);
-      when(capabilityService.getCapabilities(mockUserPrincipal))
-          .thenReturn(CapabilitiesDto.create().maxGroupMembers(128));
-
-      RoomCreationFieldsDto creationFields =
-          RoomCreationFieldsDto.create()
-              .name("room1")
-              .description("Room one")
-              .type(RoomTypeDto.GROUP)
-              .members(
-                  List.of(MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id)));
-      ChatsHttpException exception =
-          assertThrows(
-              NotFoundException.class,
-              () -> roomService.createRoom(creationFields, mockUserPrincipal));
-      assertEquals(Status.NOT_FOUND.getStatusCode(), exception.getHttpStatusCode());
-      assertEquals(Status.NOT_FOUND.getReasonPhrase(), exception.getHttpStatusPhrase());
-      assertEquals(
-          String.format("Not Found - User with identifier '%s' not found", user2Id),
-          exception.getMessage());
     }
   }
 

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/RoomsApiIT.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/RoomsApiIT.java
@@ -903,7 +903,7 @@ public class RoomsApiIT {
     class InsertOneToOneRoomTests {
 
       @Test
-      @DisplayName("Given creation fields, inserts a new one to one room and returns its data")
+      @DisplayName("Given creation fields, inserts a new one-to-one room and returns its data")
       void insertOneToOneRoom_testOk() throws Exception {
         Instant executionInstant = Instant.now().truncatedTo(ChronoUnit.SECONDS);
 
@@ -1024,7 +1024,7 @@ public class RoomsApiIT {
 
       @Test
       @DisplayName(
-          "Given creation fields for a one to one room, if there is a room with those users returns"
+          "Given creation fields for a one-to-one room, if there is a room with those users returns"
               + " a status code 409")
       void insertOneToOneRoom_testAlreadyExists() throws Exception {
         UUID roomId = UUID.randomUUID();
@@ -1492,7 +1492,7 @@ public class RoomsApiIT {
     }
 
     @Test
-    @DisplayName("Given a room identifier, if it is a one to one return status code 400")
+    @DisplayName("Given a room identifier, if it is a one-to-one return status code 400")
     void updateRoom_testErrorUpdateRoom1to1() throws Exception {
       UUID roomId = UUID.randomUUID();
       integrationTestUtils.generateAndSaveRoom(
@@ -2816,7 +2816,7 @@ public class RoomsApiIT {
     }
 
     @Test
-    @DisplayName("Given a room identifier, if the room is one to one returns status code 400")
+    @DisplayName("Given a room identifier, if the room is one-to-one returns status code 400")
     void insertRoomMembers_oneToOneTest() throws Exception {
       UUID roomId = UUID.randomUUID();
       integrationTestUtils.generateAndSaveRoom(
@@ -3408,7 +3408,7 @@ public class RoomsApiIT {
 
     @Test
     @DisplayName(
-        "Given a room identifier and a member identifier, if the room is a one to one returns"
+        "Given a room identifier and a member identifier, if the room is a one-to-one returns"
             + " status code 403")
     void deleteRoomMember_testErrorRoomOneToOne() throws Exception {
       UUID roomId = UUID.randomUUID();

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/RoomsApiIT.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/RoomsApiIT.java
@@ -394,7 +394,11 @@ public class RoomsApiIT {
               dispatcher.post(
                   URL,
                   getInsertRoomRequestBody(
-                      "testRoom", "Test room", RoomTypeDto.GROUP, List.of(user2Id, user3Id)),
+                      "testRoom",
+                      "Test room",
+                      RoomTypeDto.GROUP,
+                      List.of(
+                          MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id))),
                   user1Token);
         }
         clock.removeFixTime();
@@ -409,18 +413,137 @@ public class RoomsApiIT {
         assertEquals("Test room", room.getDescription());
         assertEquals(RoomTypeDto.GROUP, room.getType());
         assertEquals(3, room.getMembers().size());
-        assertTrue(
-            room.getMembers().stream().anyMatch(member -> user1Id.equals(member.getUserId())));
-        assertTrue(
+
+        Optional<MemberDto> user1 =
             room.getMembers().stream()
-                .filter(member -> user1Id.equals(member.getUserId()))
-                .findAny()
-                .orElseThrow()
-                .isOwner());
-        assertTrue(
-            room.getMembers().stream().anyMatch(member -> user2Id.equals(member.getUserId())));
-        assertTrue(
-            room.getMembers().stream().anyMatch(member -> user3Id.equals(member.getUserId())));
+                .filter(member -> member.getUserId().equals(user1Id))
+                .findFirst();
+        assertTrue(user1.isPresent());
+        assertTrue(user1.get().isOwner());
+        Optional<MemberDto> user2 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user2Id))
+                .findFirst();
+        assertTrue(user2.isPresent());
+        assertFalse(user2.get().isOwner());
+        Optional<MemberDto> user3 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user3Id))
+                .findFirst();
+        assertTrue(user3.isPresent());
+        assertFalse(user3.get().isOwner());
+
+        assertEquals(executionInstant, room.getCreatedAt().toInstant());
+        assertEquals(executionInstant, room.getUpdatedAt().toInstant());
+        assertNull(room.getPictureUpdatedAt());
+
+        mongooseImMockServer.verify(
+            mongooseImMockServer.getCreateRoomRequest(roomId.toString(), user1Id.toString()),
+            VerificationTimes.exactly(1));
+        mongooseImMockServer.verify(
+            mongooseImMockServer.getAddRoomMemberRequest(
+                roomId.toString(), user1Id.toString(), user2Id.toString()),
+            VerificationTimes.exactly(1));
+        mongooseImMockServer.verify(
+            mongooseImMockServer.getSendStanzaRequest(hopedXmppAffiliationMessage1),
+            VerificationTimes.exactly(1));
+        mongooseImMockServer.verify(
+            mongooseImMockServer.getAddRoomMemberRequest(
+                roomId.toString(), user1Id.toString(), user3Id.toString()),
+            VerificationTimes.exactly(1));
+        mongooseImMockServer.verify(
+            mongooseImMockServer.getSendStanzaRequest(hopedXmppAffiliationMessage2),
+            VerificationTimes.exactly(1));
+      }
+
+      @Test
+      @DisplayName(
+          "Given creation fields, inserts a new group room settings the owners and returns its"
+              + " data")
+      void insertGroupRoom_testOkWithOwners() throws Exception {
+        Instant executionInstant = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+
+        clock.fixTimeAt(executionInstant);
+        MockHttpResponse response;
+        UUID roomId = UUID.fromString("86cc37de-1217-4056-8c95-69997a6bccce");
+        mongooseImMockServer.mockCreateRoom(roomId.toString(), user1Id.toString(), true);
+        mongooseImMockServer.mockAddRoomMember(
+            roomId.toString(), user1Id.toString(), user2Id.toString(), true);
+        String hopedXmppAffiliationMessage1 =
+            String.format(
+                    "<message xmlns='jabber:client' from='%s@carbonio' to='%s@muclight.carbonio'"
+                        + " type='groupchat'>",
+                    user1Id, roomId)
+                + "<x xmlns='urn:xmpp:muclight:0#configuration'>"
+                + "<operation>memberAdded</operation>"
+                + String.format("<user-id>%s</user-id>", user2Id)
+                + "</x>"
+                + "<body/>"
+                + "</message>";
+        mongooseImMockServer.mockSendStanza(hopedXmppAffiliationMessage1, true);
+        mongooseImMockServer.mockAddRoomMember(
+            roomId.toString(), user1Id.toString(), user3Id.toString(), true);
+        String hopedXmppAffiliationMessage2 =
+            String.format(
+                    "<message xmlns='jabber:client' from='%s@carbonio' to='%s@muclight.carbonio'"
+                        + " type='groupchat'>",
+                    user1Id, roomId)
+                + "<x xmlns='urn:xmpp:muclight:0#configuration'>"
+                + "<operation>memberAdded</operation>"
+                + String.format("<user-id>%s</user-id>", user3Id)
+                + "</x>"
+                + "<body/>"
+                + "</message>";
+        mongooseImMockServer.mockSendStanza(hopedXmppAffiliationMessage2, true);
+        try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
+          uuid.when(UUID::randomUUID).thenReturn(roomId);
+          uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
+          uuid.when(() -> UUID.fromString(user2Id.toString())).thenReturn(user2Id);
+          uuid.when(() -> UUID.fromString(user3Id.toString())).thenReturn(user3Id);
+          uuid.when(() -> UUID.fromString(roomId.toString())).thenReturn(roomId);
+          response =
+              dispatcher.post(
+                  URL,
+                  getInsertRoomRequestBody(
+                      "testRoom",
+                      "Test room",
+                      RoomTypeDto.GROUP,
+                      List.of(
+                          MemberDto.create().userId(user2Id).owner(true),
+                          MemberDto.create().userId(user3Id))),
+                  user1Token);
+        }
+        clock.removeFixTime();
+        userManagementMockServer.verify(
+            "GET", String.format("/users/id/%s", user2Id), user1Token, 1);
+        userManagementMockServer.verify(
+            "GET", String.format("/users/id/%s", user3Id), user1Token, 1);
+        assertEquals(201, response.getStatus());
+        RoomDto room = objectMapper.readValue(response.getContentAsString(), RoomDto.class);
+        assertEquals("testRoom", room.getName());
+        assertEquals("Test room", room.getDescription());
+        assertEquals(RoomTypeDto.GROUP, room.getType());
+        assertEquals(3, room.getMembers().size());
+
+        Optional<MemberDto> user1 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user1Id))
+                .findFirst();
+        assertTrue(user1.isPresent());
+        assertTrue(user1.get().isOwner());
+        Optional<MemberDto> user2 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user2Id))
+                .findFirst();
+        assertTrue(user2.isPresent());
+        assertTrue(user2.get().isOwner());
+        Optional<MemberDto> user3 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user3Id))
+                .findFirst();
+        assertTrue(user3.isPresent());
+        assertFalse(user3.get().isOwner());
+
         assertEquals(executionInstant, room.getCreatedAt().toInstant());
         assertEquals(executionInstant, room.getUpdatedAt().toInstant());
         assertNull(room.getPictureUpdatedAt());
@@ -451,7 +574,11 @@ public class RoomsApiIT {
             dispatcher.post(
                 URL,
                 getInsertRoomRequestBody(
-                    null, "Test room", RoomTypeDto.GROUP, List.of(user2Id, user3Id)),
+                    null,
+                    "Test room",
+                    RoomTypeDto.GROUP,
+                    List.of(
+                        MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id))),
                 user1Token);
 
         assertEquals(400, response.getStatus());
@@ -468,7 +595,10 @@ public class RoomsApiIT {
             dispatcher.post(
                 URL,
                 getInsertRoomRequestBody(
-                    "testRoom", "Test room", RoomTypeDto.GROUP, List.of(user2Id)),
+                    "testRoom",
+                    "Test room",
+                    RoomTypeDto.GROUP,
+                    List.of(MemberDto.create().userId(user2Id))),
                 user1Token);
 
         assertEquals(400, response.getStatus());
@@ -528,7 +658,11 @@ public class RoomsApiIT {
               dispatcher.post(
                   URL,
                   getInsertRoomRequestBody(
-                      "testRoom", "Test room", RoomTypeDto.TEMPORARY, List.of(user2Id, user3Id)),
+                      "testRoom",
+                      "Test room",
+                      RoomTypeDto.TEMPORARY,
+                      List.of(
+                          MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id))),
                   user1Token);
         }
         clock.removeFixTime();
@@ -543,18 +677,137 @@ public class RoomsApiIT {
         assertEquals("Test room", room.getDescription());
         assertEquals(RoomTypeDto.TEMPORARY, room.getType());
         assertEquals(3, room.getMembers().size());
-        assertTrue(
-            room.getMembers().stream().anyMatch(member -> user1Id.equals(member.getUserId())));
-        assertTrue(
+
+        Optional<MemberDto> user1 =
             room.getMembers().stream()
-                .filter(member -> user1Id.equals(member.getUserId()))
-                .findAny()
-                .orElseThrow()
-                .isOwner());
-        assertTrue(
-            room.getMembers().stream().anyMatch(member -> user2Id.equals(member.getUserId())));
-        assertTrue(
-            room.getMembers().stream().anyMatch(member -> user3Id.equals(member.getUserId())));
+                .filter(member -> member.getUserId().equals(user1Id))
+                .findFirst();
+        assertTrue(user1.isPresent());
+        assertTrue(user1.get().isOwner());
+        Optional<MemberDto> user2 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user2Id))
+                .findFirst();
+        assertTrue(user2.isPresent());
+        assertFalse(user2.get().isOwner());
+        Optional<MemberDto> user3 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user3Id))
+                .findFirst();
+        assertTrue(user3.isPresent());
+        assertFalse(user3.get().isOwner());
+
+        assertEquals(executionInstant, room.getCreatedAt().toInstant());
+        assertEquals(executionInstant, room.getUpdatedAt().toInstant());
+        assertNull(room.getPictureUpdatedAt());
+
+        mongooseImMockServer.verify(
+            mongooseImMockServer.getCreateRoomRequest(roomId.toString(), user1Id.toString()),
+            VerificationTimes.exactly(1));
+        mongooseImMockServer.verify(
+            mongooseImMockServer.getAddRoomMemberRequest(
+                roomId.toString(), user1Id.toString(), user2Id.toString()),
+            VerificationTimes.exactly(1));
+        mongooseImMockServer.verify(
+            mongooseImMockServer.getSendStanzaRequest(hopedXmppAffiliationMessage1),
+            VerificationTimes.exactly(1));
+        mongooseImMockServer.verify(
+            mongooseImMockServer.getAddRoomMemberRequest(
+                roomId.toString(), user1Id.toString(), user3Id.toString()),
+            VerificationTimes.exactly(1));
+        mongooseImMockServer.verify(
+            mongooseImMockServer.getSendStanzaRequest(hopedXmppAffiliationMessage2),
+            VerificationTimes.exactly(1));
+      }
+
+      @Test
+      @DisplayName(
+          "Given creation fields, inserts a new temporary room settings the owners and returns its"
+              + " data")
+      void insertTemporaryRoom_testOkWithOwners() throws Exception {
+        Instant executionInstant = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+
+        clock.fixTimeAt(executionInstant);
+        MockHttpResponse response;
+        UUID roomId = UUID.fromString("86cc37de-1217-4056-8c95-69997a6bccce");
+        mongooseImMockServer.mockCreateRoom(roomId.toString(), user1Id.toString(), true);
+        mongooseImMockServer.mockAddRoomMember(
+            roomId.toString(), user1Id.toString(), user2Id.toString(), true);
+        String hopedXmppAffiliationMessage1 =
+            String.format(
+                    "<message xmlns='jabber:client' from='%s@carbonio' to='%s@muclight.carbonio'"
+                        + " type='groupchat'>",
+                    user1Id, roomId)
+                + "<x xmlns='urn:xmpp:muclight:0#configuration'>"
+                + "<operation>memberAdded</operation>"
+                + String.format("<user-id>%s</user-id>", user2Id)
+                + "</x>"
+                + "<body/>"
+                + "</message>";
+        mongooseImMockServer.mockSendStanza(hopedXmppAffiliationMessage1, true);
+        mongooseImMockServer.mockAddRoomMember(
+            roomId.toString(), user1Id.toString(), user3Id.toString(), true);
+        String hopedXmppAffiliationMessage2 =
+            String.format(
+                    "<message xmlns='jabber:client' from='%s@carbonio' to='%s@muclight.carbonio'"
+                        + " type='groupchat'>",
+                    user1Id, roomId)
+                + "<x xmlns='urn:xmpp:muclight:0#configuration'>"
+                + "<operation>memberAdded</operation>"
+                + String.format("<user-id>%s</user-id>", user3Id)
+                + "</x>"
+                + "<body/>"
+                + "</message>";
+        mongooseImMockServer.mockSendStanza(hopedXmppAffiliationMessage2, true);
+        try (MockedStatic<UUID> uuid = Mockito.mockStatic(UUID.class)) {
+          uuid.when(UUID::randomUUID).thenReturn(roomId);
+          uuid.when(() -> UUID.fromString(user1Id.toString())).thenReturn(user1Id);
+          uuid.when(() -> UUID.fromString(user2Id.toString())).thenReturn(user2Id);
+          uuid.when(() -> UUID.fromString(user3Id.toString())).thenReturn(user3Id);
+          uuid.when(() -> UUID.fromString(roomId.toString())).thenReturn(roomId);
+          response =
+              dispatcher.post(
+                  URL,
+                  getInsertRoomRequestBody(
+                      "testRoom",
+                      "Test room",
+                      RoomTypeDto.TEMPORARY,
+                      List.of(
+                          MemberDto.create().userId(user2Id).owner(true),
+                          MemberDto.create().userId(user3Id))),
+                  user1Token);
+        }
+        clock.removeFixTime();
+        userManagementMockServer.verify(
+            "GET", String.format("/users/id/%s", user2Id), user1Token, 1);
+        userManagementMockServer.verify(
+            "GET", String.format("/users/id/%s", user3Id), user1Token, 1);
+        assertEquals(201, response.getStatus());
+        RoomDto room = objectMapper.readValue(response.getContentAsString(), RoomDto.class);
+        assertEquals("testRoom", room.getName());
+        assertEquals("Test room", room.getDescription());
+        assertEquals(RoomTypeDto.TEMPORARY, room.getType());
+        assertEquals(3, room.getMembers().size());
+
+        Optional<MemberDto> user1 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user1Id))
+                .findFirst();
+        assertTrue(user1.isPresent());
+        assertTrue(user1.get().isOwner());
+        Optional<MemberDto> user2 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user2Id))
+                .findFirst();
+        assertTrue(user2.isPresent());
+        assertTrue(user2.get().isOwner());
+        Optional<MemberDto> user3 =
+            room.getMembers().stream()
+                .filter(member -> member.getUserId().equals(user3Id))
+                .findFirst();
+        assertTrue(user3.isPresent());
+        assertFalse(user3.get().isOwner());
+
         assertEquals(executionInstant, room.getCreatedAt().toInstant());
         assertEquals(executionInstant, room.getUpdatedAt().toInstant());
         assertNull(room.getPictureUpdatedAt());
@@ -585,7 +838,11 @@ public class RoomsApiIT {
             dispatcher.post(
                 URL,
                 getInsertRoomRequestBody(
-                    null, "Test room", RoomTypeDto.TEMPORARY, List.of(user2Id, user3Id)),
+                    null,
+                    "Test room",
+                    RoomTypeDto.TEMPORARY,
+                    List.of(
+                        MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id))),
                 user1Token);
 
         assertEquals(400, response.getStatus());
@@ -623,14 +880,14 @@ public class RoomsApiIT {
         assertEquals("Test room", room.getDescription());
         assertEquals(RoomTypeDto.TEMPORARY, room.getType());
         assertEquals(1, room.getMembers().size());
-        assertTrue(
-            room.getMembers().stream().anyMatch(member -> user1Id.equals(member.getUserId())));
-        assertTrue(
+
+        Optional<MemberDto> user1 =
             room.getMembers().stream()
-                .filter(member -> user1Id.equals(member.getUserId()))
-                .findAny()
-                .orElseThrow()
-                .isOwner());
+                .filter(member -> member.getUserId().equals(user1Id))
+                .findFirst();
+        assertTrue(user1.isPresent());
+        assertTrue(user1.get().isOwner());
+
         assertEquals(executionInstant, room.getCreatedAt().toInstant());
         assertEquals(executionInstant, room.getUpdatedAt().toInstant());
         assertNull(room.getPictureUpdatedAt());
@@ -677,7 +934,11 @@ public class RoomsApiIT {
           response =
               dispatcher.post(
                   URL,
-                  getInsertRoomRequestBody(null, null, RoomTypeDto.ONE_TO_ONE, List.of(user2Id)),
+                  getInsertRoomRequestBody(
+                      null,
+                      null,
+                      RoomTypeDto.ONE_TO_ONE,
+                      List.of(MemberDto.create().userId(user2Id))),
                   user1Token);
         }
         clock.removeFixTime();
@@ -727,7 +988,11 @@ public class RoomsApiIT {
             dispatcher.post(
                 URL,
                 getInsertRoomRequestBody(
-                    "testOneToOne", null, RoomTypeDto.ONE_TO_ONE, List.of(user2Id, user3Id)),
+                    "testOneToOne",
+                    null,
+                    RoomTypeDto.ONE_TO_ONE,
+                    List.of(
+                        MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id))),
                 user1Token);
 
         assertEquals(400, response.getStatus());
@@ -744,7 +1009,11 @@ public class RoomsApiIT {
             dispatcher.post(
                 URL,
                 getInsertRoomRequestBody(
-                    null, "Test room", RoomTypeDto.ONE_TO_ONE, List.of(user2Id, user3Id)),
+                    null,
+                    "Test room",
+                    RoomTypeDto.ONE_TO_ONE,
+                    List.of(
+                        MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id))),
                 user1Token);
 
         assertEquals(400, response.getStatus());
@@ -769,7 +1038,11 @@ public class RoomsApiIT {
         MockHttpResponse response =
             dispatcher.post(
                 URL,
-                getInsertRoomRequestBody(null, null, RoomTypeDto.ONE_TO_ONE, List.of(user2Id)),
+                getInsertRoomRequestBody(
+                    null,
+                    null,
+                    RoomTypeDto.ONE_TO_ONE,
+                    List.of(MemberDto.create().userId(user2Id))),
                 user1Token);
         assertEquals(409, response.getStatus());
         assertEquals(0, response.getOutput().length);
@@ -786,7 +1059,11 @@ public class RoomsApiIT {
             dispatcher.post(
                 URL,
                 getInsertRoomRequestBody(
-                    null, null, RoomTypeDto.ONE_TO_ONE, List.of(user2Id, user3Id)),
+                    null,
+                    null,
+                    RoomTypeDto.ONE_TO_ONE,
+                    List.of(
+                        MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id))),
                 user1Token);
 
         assertEquals(400, response.getStatus());
@@ -803,7 +1080,10 @@ public class RoomsApiIT {
           dispatcher.post(
               URL,
               getInsertRoomRequestBody(
-                  null, "Test room", RoomTypeDto.GROUP, List.of(user2Id, user3Id)),
+                  null,
+                  "Test room",
+                  RoomTypeDto.GROUP,
+                  List.of(MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id))),
               user1Token);
 
       assertEquals(400, response.getStatus());
@@ -819,7 +1099,10 @@ public class RoomsApiIT {
           dispatcher.post(
               URL,
               getInsertRoomRequestBody(
-                  "room", "Room", RoomTypeDto.GROUP, List.of(user2Id, user3Id)),
+                  "room",
+                  "Room",
+                  RoomTypeDto.GROUP,
+                  List.of(MemberDto.create().userId(user2Id), MemberDto.create().userId(user3Id))),
               null);
 
       assertEquals(401, response.getStatus());
@@ -833,7 +1116,13 @@ public class RoomsApiIT {
           dispatcher.post(
               URL,
               getInsertRoomRequestBody(
-                  "room", "Room", RoomTypeDto.GROUP, List.of(user2Id, user2Id, user3Id)),
+                  "room",
+                  "Room",
+                  RoomTypeDto.GROUP,
+                  List.of(
+                      MemberDto.create().userId(user2Id),
+                      MemberDto.create().userId(user2Id),
+                      MemberDto.create().userId(user3Id))),
               user1Token);
 
       assertEquals(400, response.getStatus());
@@ -850,7 +1139,13 @@ public class RoomsApiIT {
           dispatcher.post(
               URL,
               getInsertRoomRequestBody(
-                  "room", "Room", RoomTypeDto.GROUP, List.of(user1Id, user2Id, user3Id)),
+                  "room",
+                  "Room",
+                  RoomTypeDto.GROUP,
+                  List.of(
+                      MemberDto.create().userId(user1Id),
+                      MemberDto.create().userId(user2Id),
+                      MemberDto.create().userId(user3Id))),
               user1Token);
 
       assertEquals(400, response.getStatus());
@@ -868,7 +1163,10 @@ public class RoomsApiIT {
                   "testRoom",
                   "Test room",
                   RoomTypeDto.GROUP,
-                  List.of(user2Id, user3Id, UUID.randomUUID())),
+                  List.of(
+                      MemberDto.create().userId(user2Id),
+                      MemberDto.create().userId(user3Id),
+                      MemberDto.create().userId(UUID.randomUUID()))),
               user1Token);
 
       assertEquals(404, response.getStatus());
@@ -880,7 +1178,7 @@ public class RoomsApiIT {
         @Nullable String name,
         @Nullable String description,
         @Nullable RoomTypeDto type,
-        @Nullable List<UUID> membersIds) {
+        @Nullable List<MemberDto> members) {
       StringBuilder stringBuilder = new StringBuilder();
 
       Optional.ofNullable(name)
@@ -889,13 +1187,17 @@ public class RoomsApiIT {
           .ifPresent(d -> stringBuilder.append(String.format("\"description\": \"%s\",", d)));
       Optional.ofNullable(type)
           .ifPresent(t -> stringBuilder.append(String.format("\"type\": \"%s\",", t)));
-      Optional.ofNullable(membersIds)
+      Optional.ofNullable(members)
           .ifPresent(
-              ids -> {
-                stringBuilder.append("\"membersIds\": [");
+              memberList -> {
+                stringBuilder.append("\"members\": [");
                 stringBuilder.append(
-                    ids.stream()
-                        .map(id -> String.format("\"%s\"", id))
+                    memberList.stream()
+                        .map(
+                            member ->
+                                String.format(
+                                    "{\"userId\": \"%s\", \"owner\": \"%s\"}",
+                                    member.getUserId(), member.isOwner()))
                         .collect(Collectors.joining(",")));
                 stringBuilder.append("]");
               });
@@ -3374,7 +3676,6 @@ public class RoomsApiIT {
         "Given a room identifier, correctly returns a single paged list of attachments info of the"
             + " required room")
     void listRoomAttachmentInfo_testOkSinglePage() throws Exception {
-
       UUID room1Id = UUID.randomUUID();
       integrationTestUtils.generateAndSaveRoom(
           room1Id, RoomTypeDto.GROUP, "room1", List.of(user1Id, user2Id, user3Id));
@@ -3435,7 +3736,6 @@ public class RoomsApiIT {
         "Given a room identifier, correctly returns multiple paged lists of attachments info of the"
             + " required room")
     void listRoomAttachmentInfo_testOkMultiplePages() throws Exception {
-
       UUID room1Id = UUID.randomUUID();
       integrationTestUtils.generateAndSaveRoom(
           room1Id, RoomTypeDto.GROUP, "room1", List.of(user1Id, user2Id, user3Id));

--- a/carbonio-ws-collaboration-openapi/src/main/resources/chats/chats-api.yaml
+++ b/carbonio-ws-collaboration-openapi/src/main/resources/chats/chats-api.yaml
@@ -174,7 +174,6 @@ paths:
           $ref: '#/components/responses/403ForbiddenResponse'
         404:
           $ref: '#/components/responses/404NotFoundResponse'
-
   /rooms/{roomId}/mute:
     put:
       tags:
@@ -1207,12 +1206,9 @@ components:
             type:
               $ref: '#/components/schemas/RoomType'
       properties:
-        membersIds:
-          type: array
+        members:
           items:
-            type: string
-            format: uuid
-          description: members identifiers list to be subscribed to the room
+            $ref: '#/components/schemas/Member'
       required: [ type ]
     Room:
       type: object
@@ -1288,7 +1284,7 @@ components:
           type: boolean
           default: false
           description: indicates whether it is the owner
-      required: [ userId, owner ]
+      required: [ userId ]
     MemberToInsert:
       type: object
       description: Information about the member to insert in the room

--- a/carbonio-ws-collaboration-openapi/src/main/resources/chats/chats-api.yaml
+++ b/carbonio-ws-collaboration-openapi/src/main/resources/chats/chats-api.yaml
@@ -1209,6 +1209,7 @@ components:
         members:
           items:
             $ref: '#/components/schemas/Member'
+          description: list of users to add to the room
       required: [ type ]
     Room:
       type: object
@@ -1244,11 +1245,10 @@ components:
               description: |
                 room profile picture update timestamp,
                 returned only if the room picture was set at least once
-            members:
+            children:
               type: array
               items:
-                $ref: '#/components/schemas/Member'
-              description: list of users subscribed to the room
+                $ref: '#/components/schemas/Room'
             userSettings:
               $ref: '#/components/schemas/RoomUserSettings'
       required: [ id, createdAt, updatedAt ]

--- a/carbonio-ws-collaboration-openapi/src/main/resources/chats/chats-api.yaml
+++ b/carbonio-ws-collaboration-openapi/src/main/resources/chats/chats-api.yaml
@@ -68,9 +68,9 @@ paths:
       summary: Insert a room of the specified type
       description: |
         Inserts a room of the specified type. The user performing the request will be included in the final members
-        list if not specified. If the room is a one to one, only a single member can be specified and name and
-        description are replaced with an empty string. If the room is not a one to
-        one, there must be at least two members specified.
+        list if not specified. If the room is a one-to-one, only a single member can be specified and name and
+        description are replaced with an empty string. If the room is not a one-to-one,
+        there must be at least two members specified.
       operationId: insertRoom
       requestBody:
         $ref: '#/components/requestBodies/InsertRoomRequest'

--- a/carbonio-ws-collaboration-openapi/src/main/resources/chats/chats-api.yaml
+++ b/carbonio-ws-collaboration-openapi/src/main/resources/chats/chats-api.yaml
@@ -237,17 +237,17 @@ paths:
       tags:
         - Rooms
         - Members
-      summary: Adds or invites the specified user to the room
+      summary: Add or invite the specified users to the room
       description: |
-        Adds the specified user to the room. This can only be performed by an owner of the given room
-      operationId: insertRoomMember
+        Add the specified users to the room. This can only be performed by an owner of the given room
+      operationId: insertRoomMembers
       parameters:
         - $ref: '#/components/parameters/pathRoomId'
       requestBody:
-        $ref: '#/components/requestBodies/InsertRoomMemberRequest'
+        $ref: '#/components/requestBodies/InsertRoomMembersRequest'
       responses:
         201:
-          $ref: '#/components/responses/200InsertRoomMemberResponse'
+          $ref: '#/components/responses/200InsertRoomMembersResponse'
         400:
           $ref: '#/components/responses/400BadRequestResponse'
         403:
@@ -821,13 +821,13 @@ components:
           schema:
             type: string
             format: binary
-    InsertRoomMemberRequest:
-      description: member to add or invite
+    InsertRoomMembersRequest:
+      description: members to add or invite
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/MemberToInsert'
+            $ref: '#/components/schemas/MembersToInsert'
     InsertAttachmentRequest:
       description: file stream
       required: true
@@ -923,12 +923,12 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/Member'
-    200InsertRoomMemberResponse:
-      description: The member added or invited
+    200InsertRoomMembersResponse:
+      description: The members added or invited
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/MemberInserted'
+            $ref: '#/components/schemas/MembersInserted'
     204DeleteRoomMemberResponse:
       description: The member was deleted correctly or it never existed
     204UpdateToOwnerResponse:
@@ -1285,19 +1285,30 @@ components:
           default: false
           description: indicates whether it is the owner
       required: [ userId ]
+    MembersToInsert:
+      type: array
+      description: members to insert in the room
+      items:
+        $ref: '#/components/schemas/MemberToInsert'
     MemberToInsert:
       type: object
-      description: Information about the member to insert in the room
+      description: Information about the members to insert in the room
       allOf:
         - $ref: '#/components/schemas/Member'
         - type: object
           properties:
             historyCleared:
               type: boolean
+              default: false
               description: |
                 indicates whether it can see previous messages,
                 after it has been added to the room
           required: [ userId, owner, historyCleared ]
+    MembersInserted:
+      type: array
+      description: members inserted in the room
+      items:
+        $ref: '#/components/schemas/MemberInserted'
     MemberInserted:
       type: object
       description: Information about the member to inserted in the room


### PR DESCRIPTION
Both APIs have been refactored to allow bulk requests for members or owners:

- insert room API now accepts a list of objects, each of them formed by a user
identifier and a boolean indicating if the user will be a moderator of the room
- add member API now accepts a list of objects, each of them formed by a user
identifier, a boolean indicating if the user will be a moderator of the room
and another boolean indicating if the chat has to be cleared when the user
joins the room.

ref: WSC-1739