### PR TITLE
chore: update insert room member in MembersServiceImpl (#91)

### DIFF
--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImpl.java
@@ -119,11 +119,12 @@ public class MembersServiceImpl implements MembersService {
 
     validateInsertRoomMembers(memberIds, room, currentUser);
 
+    OffsetDateTime currentDateTime = OffsetDateTime.now();
     List<MemberInsertedDto> membersInserted = new ArrayList<>();
     for (MemberToInsertDto member : membersToInsert) {
       messageDispatcher.addRoomMember(
           room.getId(), currentUser.getId(), member.getUserId().toString());
-      MemberInsertedDto memberInsertedDto = processRoomSubscription(room, member);
+      MemberInsertedDto memberInsertedDto = processRoomSubscription(room, member, currentDateTime);
 
       membersInserted.add(memberInsertedDto);
       eventDispatcher.sendToUserExchange(
@@ -220,9 +221,8 @@ public class MembersServiceImpl implements MembersService {
             });
   }
 
-  private MemberInsertedDto processRoomSubscription(Room room, MemberToInsertDto member) {
-    OffsetDateTime dateTime = OffsetDateTime.now();
-
+  private MemberInsertedDto processRoomSubscription(
+      Room room, MemberToInsertDto member, OffsetDateTime dateTime) {
     Subscription subscription =
         subscriptionRepository.insert(
             Subscription.create()

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImplTest.java
@@ -13,11 +13,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.zextras.carbonio.chats.core.annotations.UnitTest;
+import com.zextras.carbonio.chats.core.data.entity.Meeting;
+import com.zextras.carbonio.chats.core.data.entity.Participant;
 import com.zextras.carbonio.chats.core.data.entity.Room;
 import com.zextras.carbonio.chats.core.data.entity.RoomUserSettings;
 import com.zextras.carbonio.chats.core.data.entity.Subscription;
@@ -52,13 +53,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @UnitTest
-public class MembersServiceImplTest {
+class MembersServiceImplTest {
 
   private final RoomService roomService;
   private final SubscriptionRepository subscriptionRepository;
@@ -100,14 +102,30 @@ public class MembersServiceImplTest {
   private static UUID user3Id;
   private static UUID user4Id;
   private static UUID roomId;
+  private static UUID meetingId;
 
   @BeforeAll
-  public static void initAll() {
+  static void initAll() {
     user1Id = UUID.randomUUID();
     user2Id = UUID.randomUUID();
     user3Id = UUID.randomUUID();
     user4Id = UUID.randomUUID();
     roomId = UUID.randomUUID();
+    meetingId = UUID.randomUUID();
+  }
+
+  @AfterEach
+  void verifyAll() {
+    verifyNoMoreInteractions(
+        roomService,
+        subscriptionRepository,
+        roomUserSettingsRepository,
+        eventDispatcher,
+        userService,
+        messageDispatcher,
+        meetingService,
+        participantService,
+        capabilityService);
   }
 
   protected Room generateRoom(RoomTypeDto type) {
@@ -137,13 +155,12 @@ public class MembersServiceImplTest {
       when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
       membersService.setOwner(roomId, user2Id, true, principal);
 
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(subscriptionRepository, times(1)).update(user2subscription.owner(true));
       verify(eventDispatcher, times(1))
           .sendToUserExchange(
               List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
               RoomOwnerPromoted.create().roomId(UUID.fromString(room.getId())).userId(user2Id));
-      verifyNoMoreInteractions(subscriptionRepository, eventDispatcher);
-      verifyNoInteractions(messageDispatcher);
     }
 
     @Test
@@ -160,13 +177,12 @@ public class MembersServiceImplTest {
       when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
       membersService.setOwner(roomId, user2Id, false, principal);
 
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(subscriptionRepository, times(1)).update(user2subscription.owner(false));
       verify(eventDispatcher, times(1))
           .sendToUserExchange(
               List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
               RoomOwnerDemoted.create().roomId(UUID.fromString(room.getId())).userId(user2Id));
-      verifyNoMoreInteractions(subscriptionRepository, eventDispatcher);
-      verifyNoInteractions(messageDispatcher);
     }
 
     @Test
@@ -185,12 +201,13 @@ public class MembersServiceImplTest {
               ForbiddenException.class,
               () -> membersService.setOwner(roomId, user2Id, true, principal));
 
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
+
       assertEquals(Status.FORBIDDEN.getStatusCode(), exception.getHttpStatusCode());
       assertEquals(Status.FORBIDDEN.getReasonPhrase(), exception.getHttpStatusPhrase());
       assertEquals(
           String.format("Forbidden - User '%s' is not a member of the room", user2Id.toString()),
           exception.getMessage());
-      verifyNoInteractions(subscriptionRepository, eventDispatcher, messageDispatcher);
     }
 
     @Test
@@ -209,11 +226,12 @@ public class MembersServiceImplTest {
               BadRequestException.class,
               () -> membersService.setOwner(roomId, user2Id, true, principal));
 
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
+
       assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
       assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
       assertEquals(
           "Bad Request - Cannot set owner privileges on one_to_one rooms", exception.getMessage());
-      verifyNoInteractions(subscriptionRepository, eventDispatcher, messageDispatcher);
     }
 
     @Test
@@ -235,7 +253,6 @@ public class MembersServiceImplTest {
       assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
       assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
       assertEquals("Bad Request - Cannot set owner privileges for itself", exception.getMessage());
-      verifyNoInteractions(subscriptionRepository, eventDispatcher, messageDispatcher);
     }
   }
 
@@ -273,6 +290,7 @@ public class MembersServiceImplTest {
 
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(userService, times(1)).userExists(user2Id, principal);
+      verify(capabilityService, times(1)).getCapabilities(principal);
       verify(messageDispatcher, times(1))
           .addRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
       verify(subscriptionRepository, times(1)).insert(any(Subscription.class));
@@ -280,9 +298,6 @@ public class MembersServiceImplTest {
           .sendToUserExchange(
               List.of(user1Id.toString(), user3Id.toString(), user2Id.toString()),
               RoomMemberAdded.create().roomId(UUID.fromString(room.getId())).userId(user2Id));
-      verifyNoMoreInteractions(
-          userService, roomService, subscriptionRepository, eventDispatcher, messageDispatcher);
-      verifyNoInteractions(roomUserSettingsRepository);
     }
 
     @Test
@@ -308,9 +323,6 @@ public class MembersServiceImplTest {
       assertEquals(
           "Bad Request - Cannot add members to a one_to_one conversation", exception.getMessage());
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
-
-      verifyNoMoreInteractions(roomService, roomUserSettingsRepository);
-      verifyNoInteractions(userService, subscriptionRepository, eventDispatcher, messageDispatcher);
     }
 
     @Test
@@ -340,14 +352,7 @@ public class MembersServiceImplTest {
           String.format("Bad Request - User '%s' is already a room member", user2Id.toString()),
           exception.getMessage());
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
-
-      verifyNoMoreInteractions(roomService);
-      verifyNoInteractions(
-          userService,
-          subscriptionRepository,
-          eventDispatcher,
-          messageDispatcher,
-          roomUserSettingsRepository);
+      verify(capabilityService, times(1)).getCapabilities(principal);
     }
 
     @Test
@@ -378,10 +383,7 @@ public class MembersServiceImplTest {
           exception.getMessage());
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(userService, times(1)).userExists(user2Id, principal);
-
-      verifyNoMoreInteractions(roomService, userService);
-      verifyNoInteractions(
-          subscriptionRepository, eventDispatcher, messageDispatcher, roomUserSettingsRepository);
+      verify(capabilityService, times(1)).getCapabilities(principal);
     }
 
     @Test
@@ -415,6 +417,7 @@ public class MembersServiceImplTest {
       assertEquals(user2Id, memberInsertedDto.getUserId());
 
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
+      verify(capabilityService, times(1)).getCapabilities(principal);
       verify(userService, times(1)).userExists(user2Id, principal);
       verify(messageDispatcher, times(1))
           .addRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
@@ -429,13 +432,6 @@ public class MembersServiceImplTest {
                   .roomId(UUID.fromString(room.getId()))
                   .userId(user2Id)
                   .isOwner(false));
-      verifyNoMoreInteractions(
-          userService,
-          roomService,
-          subscriptionRepository,
-          eventDispatcher,
-          messageDispatcher,
-          roomUserSettingsRepository);
     }
 
     @Test
@@ -464,14 +460,6 @@ public class MembersServiceImplTest {
       assertEquals("Bad Request - Cannot add more members to this group", exception.getMessage());
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(capabilityService, times(1)).getCapabilities(principal);
-
-      verifyNoMoreInteractions(roomService, capabilityService);
-      verifyNoInteractions(
-          userService,
-          subscriptionRepository,
-          eventDispatcher,
-          messageDispatcher,
-          roomUserSettingsRepository);
     }
   }
 
@@ -499,6 +487,7 @@ public class MembersServiceImplTest {
               MemberDto.create().userId(user3Id).owner(true)),
           principal);
 
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(subscriptionRepository, times(1))
           .updateAll(List.of(user2subscription, user3subscription));
       verify(eventDispatcher, times(1))
@@ -509,8 +498,6 @@ public class MembersServiceImplTest {
           .sendToUserExchange(
               List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
               RoomOwnerPromoted.create().roomId(UUID.fromString(room.getId())).userId(user3Id));
-      verifyNoMoreInteractions(subscriptionRepository, eventDispatcher);
-      verifyNoInteractions(messageDispatcher);
     }
 
     @Test
@@ -533,6 +520,7 @@ public class MembersServiceImplTest {
               MemberDto.create().userId(user3Id).owner(false)),
           principal);
 
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(subscriptionRepository, times(1))
           .updateAll(List.of(user2subscription, user3subscription));
       verify(eventDispatcher, times(1))
@@ -543,8 +531,6 @@ public class MembersServiceImplTest {
           .sendToUserExchange(
               List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
               RoomOwnerDemoted.create().roomId(UUID.fromString(room.getId())).userId(user3Id));
-      verifyNoMoreInteractions(subscriptionRepository, eventDispatcher);
-      verifyNoInteractions(messageDispatcher);
     }
 
     @Test
@@ -568,14 +554,13 @@ public class MembersServiceImplTest {
                           MemberDto.create().userId(user3Id).owner(false)),
                       principal));
 
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
+
       assertEquals(Status.FORBIDDEN.getStatusCode(), exception.getHttpStatusCode());
       assertEquals(Status.FORBIDDEN.getReasonPhrase(), exception.getHttpStatusPhrase());
       assertEquals(
           String.format("Forbidden - User '%s' is not a member of the room", user2Id.toString()),
           exception.getMessage());
-
-      verifyNoMoreInteractions(subscriptionRepository, eventDispatcher);
-      verifyNoInteractions(messageDispatcher);
     }
 
     @Test
@@ -596,12 +581,13 @@ public class MembersServiceImplTest {
                   membersService.updateRoomOwners(
                       roomId, List.of(MemberDto.create().userId(user2Id).owner(true)), principal));
 
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
+
       assertEquals(Status.BAD_REQUEST.getStatusCode(), exception.getHttpStatusCode());
       assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
       assertEquals(
           "Bad Request - Cannot update owner privileges on one_to_one rooms",
           exception.getMessage());
-      verifyNoInteractions(subscriptionRepository, eventDispatcher, messageDispatcher);
     }
 
     @Test
@@ -626,7 +612,6 @@ public class MembersServiceImplTest {
       assertEquals(Status.BAD_REQUEST.getReasonPhrase(), exception.getHttpStatusPhrase());
       assertEquals(
           "Bad Request - Cannot update owner privileges for itself", exception.getMessage());
-      verifyNoInteractions(subscriptionRepository, eventDispatcher, messageDispatcher);
     }
   }
 
@@ -658,12 +643,44 @@ public class MembersServiceImplTest {
           .sendToUserExchange(
               List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
               RoomMemberRemoved.create().roomId(roomId).userId(user2Id));
-      verifyNoMoreInteractions(
-          roomService,
-          roomUserSettingsRepository,
-          subscriptionRepository,
-          eventDispatcher,
-          messageDispatcher);
+    }
+
+    @Test
+    @DisplayName("Correctly removes a member of a group room during a meeting")
+    void deleteRoomMember_groupTestOkWithMeeting() {
+      Room room = generateRoom(RoomTypeDto.GROUP);
+      room.subscriptions(
+          List.of(
+              Subscription.create(room, user1Id.toString()).owner(true),
+              Subscription.create(room, user2Id.toString()).owner(false),
+              Subscription.create(room, user3Id.toString()).owner(false)));
+      room.meetingId(meetingId.toString());
+      UserPrincipal principal = UserPrincipal.create(user1Id);
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
+      Meeting meeting =
+          Meeting.create()
+              .id(meetingId.toString())
+              .roomId(roomId.toString())
+              .participants(
+                  List.of(
+                      Participant.create().userId(user1Id.toString()),
+                      Participant.create().userId(user2Id.toString())));
+      when(meetingService.getMeetingEntity(meetingId)).thenReturn(Optional.of(meeting));
+
+      membersService.deleteRoomMember(roomId, user2Id, principal);
+
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
+      verify(meetingService, times(1)).getMeetingEntity(meetingId);
+      verify(participantService, times(1)).removeMeetingParticipant(meeting, room, user2Id);
+      verify(messageDispatcher, times(1))
+          .removeRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
+      verify(roomUserSettingsRepository, times(1))
+          .getByRoomIdAndUserId(roomId.toString(), user2Id.toString());
+      verify(subscriptionRepository, times(1)).delete(roomId.toString(), user2Id.toString());
+      verify(eventDispatcher, times(1))
+          .sendToUserExchange(
+              List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
+              RoomMemberRemoved.create().roomId(roomId).userId(user2Id));
     }
 
     @Test
@@ -690,12 +707,41 @@ public class MembersServiceImplTest {
           .sendToUserExchange(
               List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
               RoomMemberRemoved.create().roomId(roomId).userId(user1Id));
-      verifyNoMoreInteractions(
-          roomService,
-          roomUserSettingsRepository,
-          subscriptionRepository,
-          eventDispatcher,
-          messageDispatcher);
+    }
+
+    @Test
+    @DisplayName("Correctly user removes itself of a group room muted and with history cleared")
+    void deleteRoomMember_userRemoveItselfTestOkWithMuteAndHistoryCleared() {
+      Room room = generateRoom(RoomTypeDto.GROUP);
+      room.subscriptions(
+          List.of(
+              Subscription.create(room, user1Id.toString()).owner(false),
+              Subscription.create(room, user2Id.toString()).owner(true),
+              Subscription.create(room, user3Id.toString()).owner(false)));
+      RoomUserSettings roomUserSettings =
+          RoomUserSettings.create()
+              .userId(user1Id.toString())
+              .mutedUntil(OffsetDateTime.parse("0001-01-01T00:00:00Z"))
+              .clearedAt(OffsetDateTime.now());
+      room.userSettings(List.of(roomUserSettings));
+      UserPrincipal principal = UserPrincipal.create(user1Id);
+      when(roomService.getRoomAndValidateUser(roomId, principal, false)).thenReturn(room);
+      when(roomUserSettingsRepository.getByRoomIdAndUserId(roomId.toString(), user1Id.toString()))
+          .thenReturn(Optional.of(roomUserSettings));
+
+      membersService.deleteRoomMember(roomId, user1Id, principal);
+
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, false);
+      verify(messageDispatcher, times(1))
+          .removeRoomMember(roomId.toString(), user2Id.toString(), user1Id.toString());
+      verify(roomUserSettingsRepository, times(1))
+          .getByRoomIdAndUserId(roomId.toString(), user1Id.toString());
+      verify(roomUserSettingsRepository, times(1)).delete(roomUserSettings);
+      verify(subscriptionRepository, times(1)).delete(roomId.toString(), user1Id.toString());
+      verify(eventDispatcher, times(1))
+          .sendToUserExchange(
+              List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
+              RoomMemberRemoved.create().roomId(roomId).userId(user1Id));
     }
 
     @Test
@@ -719,8 +765,6 @@ public class MembersServiceImplTest {
       assertEquals("Bad Request - Last owner can't leave the room", exception.getMessage());
 
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, false);
-      verifyNoMoreInteractions(roomService);
-      verifyNoInteractions(subscriptionRepository, eventDispatcher, messageDispatcher);
     }
 
     @Test
@@ -747,8 +791,6 @@ public class MembersServiceImplTest {
           exception.getMessage());
 
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
-      verifyNoMoreInteractions(roomService);
-      verifyNoInteractions(subscriptionRepository, eventDispatcher, messageDispatcher);
     }
   }
 
@@ -775,7 +817,6 @@ public class MembersServiceImplTest {
       assertEquals(user3Id, roomMembers.get(2).getUserId());
 
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, false);
-      verifyNoMoreInteractions(roomService);
     }
   }
 


### PR DESCRIPTION
generate the clear history timestamp before the affiliation message when adding a member with history cleared enabled

* chore: add test for deleting room member with meeting
* chore: add test for deleting room member with room settings

ref: WSC-1204