### PR TITLE
fix: remove all room members to destroy the room on message-dispatcher

### DIFF
--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/MessageDispatcher.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/MessageDispatcher.java
@@ -23,14 +23,6 @@ public interface MessageDispatcher extends HealthIndicator {
   void createRoom(String roomId, String senderId, List<String> memberIds);
 
   /**
-   * Deletes a room on XMPP server
-   *
-   * @param roomId identifier of the room to delete
-   * @param userId operation user
-   */
-  void deleteRoom(String roomId, String userId);
-
-  /**
    * Sends a message to communicate that the room name has changed
    *
    * @param roomId room identifier
@@ -71,18 +63,29 @@ public interface MessageDispatcher extends HealthIndicator {
    *
    * @param roomId room identifier
    * @param senderId inviting user identifier
-   * @param recipientId invited user identifier
+   * @param memberId identifier of the user to add
    */
-  void addRoomMember(String roomId, String senderId, String recipientId);
+  void addRoomMember(String roomId, String senderId, String memberId);
 
   /**
-   * Removes a member from a room on XMPP server
+   * Removes a member from a room on XMPP server. It will destroy the room automatically when the
+   * last member is removed. Moreover, also the inbox entries and all room messages will be deleted.
+   *
+   * @param roomId room identifier
+   * @param memberId identifier of the user to remove
+   */
+  void removeRoomMember(String roomId, String memberId);
+
+  /**
+   * Sends an affiliation message to a room on XMPP server
    *
    * @param roomId room identifier
    * @param senderId operation user identifier
-   * @param userIdToRemove identifier of the user to remove
+   * @param memberId identifier of the related room member
+   * @param messageType type of the message
    */
-  void removeRoomMember(String roomId, String senderId, String userIdToRemove);
+  void sendAffiliationMessage(
+      String roomId, String senderId, String memberId, MessageType messageType);
 
   /**
    * Sets two users in their respective contacts list so that they can both see each other's

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/RoomServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/RoomServiceImpl.java
@@ -348,7 +348,9 @@ public class RoomServiceImpl implements RoomService {
                 fileMetadataRepository.delete(metadata);
               });
     }
-    messageDispatcher.deleteRoom(room.getId(), currentUser.getId());
+    room.getSubscriptions().stream()
+        .map(Subscription::getUserId)
+        .forEach(userId -> messageDispatcher.removeRoomMember(room.getId(), userId));
     roomRepository.delete(roomId.toString());
     eventDispatcher.sendToUserExchange(
         room.getSubscriptions().stream().map(Subscription::getUserId).toList(),

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImplTest.java
@@ -32,6 +32,7 @@ import com.zextras.carbonio.chats.core.exception.ForbiddenException;
 import com.zextras.carbonio.chats.core.exception.NotFoundException;
 import com.zextras.carbonio.chats.core.infrastructure.event.EventDispatcher;
 import com.zextras.carbonio.chats.core.infrastructure.messaging.MessageDispatcher;
+import com.zextras.carbonio.chats.core.infrastructure.messaging.MessageType;
 import com.zextras.carbonio.chats.core.mapper.SubscriptionMapper;
 import com.zextras.carbonio.chats.core.repository.RoomUserSettingsRepository;
 import com.zextras.carbonio.chats.core.repository.SubscriptionRepository;
@@ -293,6 +294,9 @@ class MembersServiceImplTest {
       verify(capabilityService, times(1)).getCapabilities(principal);
       verify(messageDispatcher, times(1))
           .addRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
+      verify(messageDispatcher, times(1))
+          .sendAffiliationMessage(
+              roomId.toString(), user1Id.toString(), user2Id.toString(), MessageType.MEMBER_ADDED);
       verify(subscriptionRepository, times(1)).insert(any(Subscription.class));
       verify(eventDispatcher, times(1))
           .sendToUserExchange(
@@ -421,6 +425,9 @@ class MembersServiceImplTest {
       verify(userService, times(1)).userExists(user2Id, principal);
       verify(messageDispatcher, times(1))
           .addRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
+      verify(messageDispatcher, times(1))
+          .sendAffiliationMessage(
+              roomId.toString(), user1Id.toString(), user2Id.toString(), MessageType.MEMBER_ADDED);
       verify(subscriptionRepository, times(1)).insert(any(Subscription.class));
       verify(roomUserSettingsRepository, times(1))
           .getByRoomIdAndUserId(roomId.toString(), user2Id.toString());
@@ -634,8 +641,13 @@ class MembersServiceImplTest {
       membersService.deleteRoomMember(roomId, user2Id, principal);
 
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
+      verify(messageDispatcher, times(1)).removeRoomMember(roomId.toString(), user2Id.toString());
       verify(messageDispatcher, times(1))
-          .removeRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
+          .sendAffiliationMessage(
+              roomId.toString(),
+              user1Id.toString(),
+              user2Id.toString(),
+              MessageType.MEMBER_REMOVED);
       verify(roomUserSettingsRepository, times(1))
           .getByRoomIdAndUserId(roomId.toString(), user2Id.toString());
       verify(subscriptionRepository, times(1)).delete(roomId.toString(), user2Id.toString());
@@ -672,8 +684,13 @@ class MembersServiceImplTest {
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
       verify(meetingService, times(1)).getMeetingEntity(meetingId);
       verify(participantService, times(1)).removeMeetingParticipant(meeting, room, user2Id);
+      verify(messageDispatcher, times(1)).removeRoomMember(roomId.toString(), user2Id.toString());
       verify(messageDispatcher, times(1))
-          .removeRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
+          .sendAffiliationMessage(
+              roomId.toString(),
+              user1Id.toString(),
+              user2Id.toString(),
+              MessageType.MEMBER_REMOVED);
       verify(roomUserSettingsRepository, times(1))
           .getByRoomIdAndUserId(roomId.toString(), user2Id.toString());
       verify(subscriptionRepository, times(1)).delete(roomId.toString(), user2Id.toString());
@@ -698,8 +715,13 @@ class MembersServiceImplTest {
       membersService.deleteRoomMember(roomId, user1Id, principal);
 
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, false);
+      verify(messageDispatcher, times(1)).removeRoomMember(roomId.toString(), user1Id.toString());
       verify(messageDispatcher, times(1))
-          .removeRoomMember(roomId.toString(), user2Id.toString(), user1Id.toString());
+          .sendAffiliationMessage(
+              roomId.toString(),
+              user2Id.toString(),
+              user1Id.toString(),
+              MessageType.MEMBER_REMOVED);
       verify(roomUserSettingsRepository, times(1))
           .getByRoomIdAndUserId(roomId.toString(), user1Id.toString());
       verify(subscriptionRepository, times(1)).delete(roomId.toString(), user1Id.toString());
@@ -732,8 +754,13 @@ class MembersServiceImplTest {
       membersService.deleteRoomMember(roomId, user1Id, principal);
 
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, false);
+      verify(messageDispatcher, times(1)).removeRoomMember(roomId.toString(), user1Id.toString());
       verify(messageDispatcher, times(1))
-          .removeRoomMember(roomId.toString(), user2Id.toString(), user1Id.toString());
+          .sendAffiliationMessage(
+              roomId.toString(),
+              user2Id.toString(),
+              user1Id.toString(),
+              MessageType.MEMBER_REMOVED);
       verify(roomUserSettingsRepository, times(1))
           .getByRoomIdAndUserId(roomId.toString(), user1Id.toString());
       verify(roomUserSettingsRepository, times(1)).delete(roomUserSettings);

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/RoomServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/RoomServiceImplTest.java
@@ -1200,7 +1200,12 @@ class RoomServiceImplTest {
 
       roomService.deleteRoom(roomGroup1Id, UserPrincipal.create(user1Id));
 
-      verify(messageDispatcher, times(1)).deleteRoom(roomGroup1Id.toString(), user1Id.toString());
+      verify(messageDispatcher, times(1))
+          .removeRoomMember(roomGroup1Id.toString(), user1Id.toString());
+      verify(messageDispatcher, times(1))
+          .removeRoomMember(roomGroup1Id.toString(), user2Id.toString());
+      verify(messageDispatcher, times(1))
+          .removeRoomMember(roomGroup1Id.toString(), user3Id.toString());
       verify(eventDispatcher, times(1))
           .sendToUserExchange(
               List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
@@ -1235,7 +1240,10 @@ class RoomServiceImplTest {
           .find(null, roomGroup2Id.toString(), FileMetadataType.ROOM_AVATAR);
       verify(storagesService, times(1)).deleteFile(pfpMetadata.getId(), user2Id.toString());
       verify(fileMetadataRepository, times(1)).delete(pfpMetadata);
-      verify(messageDispatcher, times(1)).deleteRoom(roomGroup2Id.toString(), user2Id.toString());
+      verify(messageDispatcher, times(1))
+          .removeRoomMember(roomGroup2Id.toString(), user2Id.toString());
+      verify(messageDispatcher, times(1))
+          .removeRoomMember(roomGroup2Id.toString(), user3Id.toString());
       verify(eventDispatcher, times(1))
           .sendToUserExchange(
               List.of(user2Id.toString(), user3Id.toString()),
@@ -1273,7 +1281,12 @@ class RoomServiceImplTest {
 
       verify(meetingService, times(1)).getMeetingEntity(meetingId);
       verify(meetingService, times(1)).deleteMeeting(user1Id.toString(), meeting, roomGroup1);
-      verify(messageDispatcher, times(1)).deleteRoom(roomGroup1Id.toString(), user1Id.toString());
+      verify(messageDispatcher, times(1))
+          .removeRoomMember(roomGroup1Id.toString(), user1Id.toString());
+      verify(messageDispatcher, times(1))
+          .removeRoomMember(roomGroup1Id.toString(), user2Id.toString());
+      verify(messageDispatcher, times(1))
+          .removeRoomMember(roomGroup1Id.toString(), user3Id.toString());
       verify(eventDispatcher, times(1))
           .sendToUserExchange(
               List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/RoomsApiIT.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/RoomsApiIT.java
@@ -1527,7 +1527,9 @@ public class RoomsApiIT {
               RoomMemberField.create().id(user1Id).owner(true),
               RoomMemberField.create().id(user2Id).muted(true),
               RoomMemberField.create().id(user3Id)));
-      mongooseImMockServer.mockDeleteRoom(roomId.toString(), true);
+      mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user1Id.toString(), true);
+      mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user2Id.toString(), true);
+      mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user3Id.toString(), true);
 
       MockHttpResponse response = dispatcher.delete(url(roomId), user1Token);
       assertEquals(204, response.getStatus());
@@ -1557,7 +1559,9 @@ public class RoomsApiIT {
                       .audioStreamOn(false)
                       .videoStreamOn(false)));
       integrationTestUtils.updateRoom(room.meetingId(meetingId.toString()));
-      mongooseImMockServer.mockDeleteRoom(roomId.toString(), true);
+      mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user1Id.toString(), true);
+      mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user2Id.toString(), true);
+      mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user3Id.toString(), true);
 
       MockHttpResponse response = dispatcher.delete(url(roomId), user1Token);
       assertEquals(204, response.getStatus());
@@ -1590,7 +1594,9 @@ public class RoomsApiIT {
                       .audioStreamOn(false)
                       .videoStreamOn(false)));
       integrationTestUtils.updateRoom(room.meetingId(meetingId.toString()));
-      mongooseImMockServer.mockDeleteRoom(roomId.toString(), true);
+      mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user1Id.toString(), true);
+      mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user2Id.toString(), true);
+      mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user3Id.toString(), true);
 
       meetingTestUtils.insertVideoServerMeeting(
           meetingId.toString(),
@@ -1676,7 +1682,9 @@ public class RoomsApiIT {
                 .mimeType("-"));
         storageMockServer.setBulkDeleteResponse(
             List.of(file1Id, file2Id), List.of(file1Id, file2Id));
-        mongooseImMockServer.mockDeleteRoom(roomId.toString(), true);
+        mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user1Id.toString(), true);
+        mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user2Id.toString(), true);
+        mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user3Id.toString(), true);
 
         MockHttpResponse response = dispatcher.delete(url(roomId), user1Token);
 
@@ -1722,7 +1730,9 @@ public class RoomsApiIT {
                 .originalSize(0L)
                 .mimeType("-"));
         storageMockServer.setBulkDeleteResponse(List.of(file1Id, file2Id), List.of(file1Id));
-        mongooseImMockServer.mockDeleteRoom(roomId.toString(), true);
+        mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user1Id.toString(), true);
+        mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user2Id.toString(), true);
+        mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user3Id.toString(), true);
 
         MockHttpResponse response = dispatcher.delete(url(roomId), user1Token);
 
@@ -1768,8 +1778,10 @@ public class RoomsApiIT {
                 .roomId(roomId.toString())
                 .originalSize(0L)
                 .mimeType("-"));
+        mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user1Id.toString(), true);
+        mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user2Id.toString(), true);
+        mongooseImMockServer.mockRemoveRoomMember(roomId.toString(), user3Id.toString(), true);
         storageMockServer.setBulkDeleteResponse(List.of(file1Id, file2Id), null);
-        mongooseImMockServer.mockDeleteRoom(roomId.toString(), true);
 
         MockHttpResponse response = dispatcher.delete(url(roomId), user1Token);
 

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/tools/MongooseImMockServer.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/tools/MongooseImMockServer.java
@@ -84,20 +84,6 @@ public class MongooseImMockServer extends ClientAndServer implements CloseableRe
     when(request).respond(getResponse(success));
   }
 
-  public HttpRequest getDeleteRoomRequest(String roomId) {
-    return getRequest(
-        "POST",
-        "{\"query\":\"mutation muc_light { muc_light { deleteRoom ("
-            + String.format("room: \\\"%s@muclight.carbonio\\\") ", roomId)
-            + "} }\",\"operationName\":\"muc_light\",\"variables\":{}}");
-  }
-
-  public void mockDeleteRoom(String roomId, boolean success) {
-    HttpRequest request = getDeleteRoomRequest(roomId);
-    clear(request);
-    when(request).respond(getResponse(success));
-  }
-
   public HttpRequest getAddRoomMemberRequest(String roomId, String senderId, String recipientId) {
     return getRequest(
         "POST",


### PR DESCRIPTION
This ensures the removal of room-related references from the inbox
and mam_muc_message within MongooseIM's message dispatcher.

ref: WSC-1910