### PR TITLE
chore: improve videoserver event listener and websocket management (#95)

### DIFF
--- a/carbonio-ws-collaboration-boot/pom.xml
+++ b/carbonio-ws-collaboration-boot/pom.xml
@@ -90,18 +90,8 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
-      <groupId>jakarta.websocket</groupId>
-      <artifactId>jakarta.websocket-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.eclipse.jetty.ee10.websocket</groupId>
       <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
-      <artifactId>jetty-ee10-websocket-jakarta-client</artifactId>
     </dependency>
 
     <dependency>

--- a/carbonio-ws-collaboration-boot/src/main/java/com/zextras/carbonio/chats/boot/Boot.java
+++ b/carbonio-ws-collaboration-boot/src/main/java/com/zextras/carbonio/chats/boot/Boot.java
@@ -5,22 +5,24 @@
 package com.zextras.carbonio.chats.boot;
 
 import com.google.inject.Inject;
+import com.zaxxer.hikari.HikariDataSource;
 import com.zextras.carbonio.chats.core.config.ChatsConstant;
+import com.zextras.carbonio.chats.core.exception.InternalErrorException;
 import com.zextras.carbonio.chats.core.infrastructure.authentication.AuthenticationService;
+import com.zextras.carbonio.chats.core.logging.ChatsLogger;
 import com.zextras.carbonio.chats.core.web.security.EventsWebSocketAuthenticationFilter;
-import com.zextras.carbonio.chats.core.web.socket.EventsWebSocketEndpoint;
 import com.zextras.carbonio.chats.core.web.socket.EventsWebSocketEndpointConfigurator;
+import com.zextras.carbonio.chats.core.web.socket.EventsWebSocketManager;
 import com.zextras.carbonio.chats.core.web.socket.VideoServerEventListener;
 import dev.resteasy.guice.GuiceResteasyBootstrapServletContextListener;
 import jakarta.servlet.DispatcherType;
 import jakarta.websocket.server.ServerEndpointConfig;
-import java.net.InetSocketAddress;
 import java.util.EnumSet;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.ee10.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.ServerConnector;
 import org.flywaydb.core.Flyway;
 import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
 
@@ -28,40 +30,50 @@ public class Boot {
 
   private final GuiceResteasyBootstrapServletContextListener resteasyListener;
   private final Flyway flyway;
+  private final HikariDataSource hikariDataSource;
   private final AuthenticationService authenticationService;
-  private final EventsWebSocketEndpoint eventsWebSocketEndpoint;
+  private final EventsWebSocketManager eventsWebSocketManager;
   private final VideoServerEventListener videoServerEventListener;
 
   @Inject
   public Boot(
       GuiceResteasyBootstrapServletContextListener resteasyListener,
       Flyway flyway,
+      HikariDataSource hikariDataSource,
       AuthenticationService authenticationService,
-      EventsWebSocketEndpoint eventsWebSocketEndpoint,
+      EventsWebSocketManager eventsWebSocketManager,
       VideoServerEventListener videoServerEventListener) {
     this.resteasyListener = resteasyListener;
     this.flyway = flyway;
+    this.hikariDataSource = hikariDataSource;
     this.authenticationService = authenticationService;
-    this.eventsWebSocketEndpoint = eventsWebSocketEndpoint;
+    this.eventsWebSocketManager = eventsWebSocketManager;
     this.videoServerEventListener = videoServerEventListener;
   }
 
   public void boot() throws Exception {
     flyway.migrate();
 
-    Server server =
-        new Server(new InetSocketAddress(ChatsConstant.SERVER_HOST, ChatsConstant.SERVER_PORT));
-    ContextHandlerCollection handlers = new ContextHandlerCollection();
+    Server server = new Server();
+    ServerConnector connector = new ServerConnector(server);
+    connector.setHost(ChatsConstant.SERVER_HOST);
+    connector.setPort(ChatsConstant.SERVER_PORT);
+    server.addConnector(connector);
 
     ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+    context.setContextPath("/");
+    server.setHandler(context);
 
     JakartaWebSocketServletContainerInitializer.configure(
         context,
         (servletContext, wsContainer) -> {
-          wsContainer.setDefaultMaxSessionIdleTimeout(0L);
+          wsContainer.setDefaultMaxSessionIdleTimeout(30_000L);
+          wsContainer.setDefaultMaxTextMessageBufferSize(65536);
+          wsContainer.setDefaultMaxBinaryMessageBufferSize(65536);
+
           wsContainer.addEndpoint(
-              ServerEndpointConfig.Builder.create(EventsWebSocketEndpoint.class, "/events")
-                  .configurator(new EventsWebSocketEndpointConfigurator(eventsWebSocketEndpoint))
+              ServerEndpointConfig.Builder.create(EventsWebSocketManager.class, "/events")
+                  .configurator(new EventsWebSocketEndpointConfigurator(eventsWebSocketManager))
                   .build());
           servletContext
               .addFilter(
@@ -75,9 +87,21 @@ public class Boot {
 
     videoServerEventListener.start();
 
-    handlers.addHandler(context);
-    server.setHandler(handlers);
     server.start();
+
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  try {
+                    hikariDataSource.close();
+                    ChatsLogger.info("Shutting down server...");
+                    server.stop();
+                  } catch (Exception e) {
+                    throw new InternalErrorException(e);
+                  }
+                }));
+
     server.join();
   }
 }

--- a/carbonio-ws-collaboration-core/pom.xml
+++ b/carbonio-ws-collaboration-core/pom.xml
@@ -57,6 +57,26 @@ SPDX-License-Identifier: AGPL-3.0-only
       <artifactId>jetty-server</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlet</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.websocket</groupId>
+      <artifactId>jakarta.websocket-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.websocket</groupId>
+      <artifactId>jakarta.websocket-client-api</artifactId>
+    </dependency>
+
     <!-- Guice dependencies -->
     <dependency>
       <groupId>com.google.inject</groupId>
@@ -77,13 +97,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-validator-provider</artifactId>
-    </dependency>
-
-    <!-- Jakarta -->
-    <dependency>
-      <groupId>jakarta.platform</groupId>
-      <artifactId>jakarta.jakartaee-api</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -157,12 +170,6 @@ SPDX-License-Identifier: AGPL-3.0-only
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
     </dependency>
-
-    <!-- Web Socket -->
-    <dependency>
-       <groupId>jakarta.websocket</groupId>
-       <artifactId>jakarta.websocket-api</artifactId>
-     </dependency>
 
     <!-- Cache -->
     <dependency>

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/cache/CacheHandler.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/cache/CacheHandler.java
@@ -8,21 +8,24 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.zextras.carbonio.chats.core.data.entity.VideoServerSession;
+import com.zextras.carbonio.chats.core.data.model.UserProfile;
 import java.time.Duration;
 
 @Singleton
 public class CacheHandler {
 
-  private final Cache<String, VideoServerSession> videoServerSessionCache;
+  private final Cache<String, UserProfile> userProfileCache;
 
   @Inject
   public CacheHandler() {
-    this.videoServerSessionCache =
-        Caffeine.newBuilder().expireAfterAccess(Duration.ofMinutes(5)).build();
+    this.userProfileCache =
+        Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(60)).maximumSize(100).build();
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(this.userProfileCache::invalidateAll, "Cache handler shutdown hook"));
   }
 
-  public Cache<String, VideoServerSession> getVideoServerSessionCache() {
-    return videoServerSessionCache;
+  public Cache<String, UserProfile> getUserProfileCache() {
+    return userProfileCache;
   }
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/config/CoreModule.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/config/CoreModule.java
@@ -111,7 +111,7 @@ import com.zextras.carbonio.chats.core.web.exceptions.DefaultExceptionHandler;
 import com.zextras.carbonio.chats.core.web.exceptions.JsonProcessingExceptionHandler;
 import com.zextras.carbonio.chats.core.web.exceptions.ValidationExceptionHandler;
 import com.zextras.carbonio.chats.core.web.security.AuthenticationFilter;
-import com.zextras.carbonio.chats.core.web.socket.EventsWebSocketEndpoint;
+import com.zextras.carbonio.chats.core.web.socket.EventsWebSocketManager;
 import com.zextras.carbonio.chats.core.web.socket.VideoServerEventListener;
 import com.zextras.carbonio.chats.core.web.utility.HttpClient;
 import com.zextras.carbonio.meeting.api.MeetingsApi;
@@ -144,7 +144,7 @@ public class CoreModule extends AbstractModule {
 
     bind(AuthenticationFilter.class);
     bind(EventDispatcher.class).to(EventDispatcherRabbitMq.class);
-    bind(EventsWebSocketEndpoint.class);
+    bind(EventsWebSocketManager.class);
 
     bind(RoomsApi.class);
     bind(RoomsApiService.class).to(RoomsApiServiceImpl.class);

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/config/JacksonConfig.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/config/JacksonConfig.java
@@ -9,11 +9,13 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.inject.Singleton;
 import com.zextras.carbonio.chats.api.RFC3339DateFormat;
 import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.Provider;
 
 @Provider
+@Singleton
 public class JacksonConfig
     implements jakarta.inject.Provider<ObjectMapper>, ContextResolver<ObjectMapper> {
 

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/data/event/DomainEvent.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/data/event/DomainEvent.java
@@ -4,14 +4,13 @@
 
 package com.zextras.carbonio.chats.core.data.event;
 
-
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
 public class DomainEvent {
 
-  private EventType      type;
-  private OffsetDateTime sentDate;
+  private final EventType type;
+  private final OffsetDateTime sentDate;
 
   public DomainEvent(EventType type) {
     this.type = type;

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/data/model/FileContentAndMetadata.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/data/model/FileContentAndMetadata.java
@@ -8,6 +8,7 @@ import com.zextras.carbonio.chats.core.data.entity.FileMetadata;
 import com.zextras.carbonio.chats.core.logging.ChatsLogger;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.StreamingOutput;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -33,19 +34,13 @@ public class FileContentAndMetadata implements StreamingOutput {
 
   @Override
   public void write(OutputStream outputStream) throws WebApplicationException {
-    try {
-      IOUtils.copyLarge(fileStream, outputStream);
+    try (InputStream in = fileStream;
+        BufferedOutputStream bufferedOut = new BufferedOutputStream(outputStream)) {
+      IOUtils.copyLarge(in, bufferedOut);
+      bufferedOut.flush();
     } catch (IOException e) {
       ChatsLogger.warn("Error occurred on the file stream " + metadata.getId(), e);
       throw new WebApplicationException("File streaming failed for " + metadata.getId(), e);
-    } finally {
-      if (fileStream != null) {
-        try {
-          fileStream.close();
-        } catch (IOException e) {
-          ChatsLogger.error("Failed to close the file stream " + metadata.getId(), e);
-        }
-      }
     }
   }
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/event/EventDispatcher.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/event/EventDispatcher.java
@@ -14,4 +14,6 @@ public interface EventDispatcher extends HealthIndicator {
   void sendToUserExchange(List<String> usersIds, DomainEvent event);
 
   void sendToUserQueue(String userId, String queueId, DomainEvent event);
+
+  void stop();
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/event/impl/EventDispatcherRabbitMq.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/event/impl/EventDispatcherRabbitMq.java
@@ -4,10 +4,10 @@
 
 package com.zextras.carbonio.chats.core.infrastructure.event.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.rabbitmq.client.BuiltinExchangeType;
 import com.rabbitmq.client.Channel;
 import com.zextras.carbonio.chats.core.data.event.DomainEvent;
 import com.zextras.carbonio.chats.core.infrastructure.event.EventDispatcher;
@@ -17,6 +17,8 @@ import java.util.List;
 
 @Singleton
 public class EventDispatcherRabbitMq implements EventDispatcher {
+
+  private static final String USER_ROUTING_KEY = "user-events";
 
   private final Channel channel;
   private final ObjectMapper objectMapper;
@@ -34,20 +36,12 @@ public class EventDispatcherRabbitMq implements EventDispatcher {
 
   @Override
   public void sendToUserExchange(String userId, DomainEvent event) {
-    try {
-      sendToExchange(userId, objectMapper.writeValueAsString(event));
-    } catch (JsonProcessingException e) {
-      ChatsLogger.warn("Unable to convert event to json", e);
-    }
+    sendToExchange(userId, event);
   }
 
   @Override
   public void sendToUserExchange(List<String> usersIds, DomainEvent event) {
-    try {
-      sendToExchange(usersIds, objectMapper.writeValueAsString(event));
-    } catch (JsonProcessingException e) {
-      ChatsLogger.warn("Unable to convert event to json", e);
-    }
+    sendToExchange(usersIds, event);
   }
 
   @Override
@@ -56,12 +50,29 @@ public class EventDispatcherRabbitMq implements EventDispatcher {
       ChatsLogger.error("Unable to send event to user queue: event dispatcher channel is not up!");
       return;
     }
-    String queueName = userId + "/" + queueId;
+    String userQueue = userId + "/" + queueId;
     try {
-      channel.queueDeclare(queueName, false, false, true, null);
+      channel.queueDeclare(queueId, false, false, true, null);
       channel.basicPublish(
           "",
-          queueName,
+          queueId,
+          null,
+          objectMapper.writeValueAsString(event).getBytes(StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      ChatsLogger.warn(String.format("Unable to send message to user queue '%s'", userQueue), e);
+    }
+  }
+
+  private void sendToExchange(String userId, DomainEvent event) {
+    if (channel == null || !channel.isOpen()) {
+      ChatsLogger.error("Unable to send event to exchange: event dispatcher channel is not up!");
+      return;
+    }
+    try {
+      channel.exchangeDeclare(userId, BuiltinExchangeType.DIRECT, false, false, null);
+      channel.basicPublish(
+          userId,
+          USER_ROUTING_KEY,
           null,
           objectMapper.writeValueAsString(event).getBytes(StandardCharsets.UTF_8));
     } catch (Exception e) {
@@ -69,20 +80,19 @@ public class EventDispatcherRabbitMq implements EventDispatcher {
     }
   }
 
-  private void sendToExchange(String userId, String event) {
-    if (channel == null || !channel.isOpen()) {
-      ChatsLogger.error("Unable to send event to exchange: event dispatcher channel is not up!");
-      return;
-    }
-    try {
-      channel.exchangeDeclare(userId, "direct");
-      channel.basicPublish(userId, "", null, event.getBytes(StandardCharsets.UTF_8));
-    } catch (Exception e) {
-      ChatsLogger.warn(String.format("Unable to send message to user '%s'", userId), e);
-    }
+  private void sendToExchange(List<String> usersIds, DomainEvent event) {
+    usersIds.forEach(userId -> sendToExchange(userId, event));
   }
 
-  private void sendToExchange(List<String> usersIds, String event) {
-    usersIds.forEach(userId -> sendToExchange(userId, event));
+  @Override
+  public void stop() {
+    try {
+      if (channel != null && channel.isOpen()) {
+        channel.close();
+        ChatsLogger.info("Event dispatcher channel closed successfully.");
+      }
+    } catch (Exception e) {
+      ChatsLogger.error("Error during stopping event dispatcher", e);
+    }
   }
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/VideoServerService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/VideoServerService.java
@@ -9,7 +9,6 @@ import com.zextras.carbonio.chats.core.infrastructure.HealthIndicator;
 import com.zextras.carbonio.meeting.model.MediaStreamSettingsDto;
 import com.zextras.carbonio.meeting.model.SubscriptionUpdatesDto;
 import java.util.List;
-import java.util.Optional;
 
 public interface VideoServerService extends HealthIndicator {
 
@@ -25,8 +24,6 @@ public interface VideoServerService extends HealthIndicator {
       boolean audioStreamOn);
 
   void destroyMeetingParticipant(String userId, String meetingId);
-
-  Optional<VideoServerSession> getSession(String connectionId);
 
   List<VideoServerSession> getSessions(String meetingId);
 

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/event/VideoServerEvent.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/event/VideoServerEvent.java
@@ -19,17 +19,18 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class VideoServerEvent {
 
-  private String    emitter;
-  private Integer   type;
-  private Integer   subtype;
-  private Long      timestamp;
-  private Long      sessionId;
-  private Long      handleId;
+  private String emitter;
+  private Integer type;
+  private Integer subtype;
+  private Long timestamp;
+  private Long sessionId;
+  private Long handleId;
+  private String opaqueId;
+
   @JsonProperty("event")
   private EventInfo eventInfo;
 
-  public VideoServerEvent() {
-  }
+  public VideoServerEvent() {}
 
   public String getEmitter() {
     return emitter;
@@ -53,6 +54,10 @@ public class VideoServerEvent {
 
   public Long getHandleId() {
     return handleId;
+  }
+
+  public String getOpaqueId() {
+    return opaqueId;
   }
 
   public EventInfo getEventInfo() {

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/media/Feed.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/media/Feed.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 public class Feed {
 
   private MediaType type;
-  private String    userId;
+  private String userId;
 
   public static Feed create() {
     return new Feed();
@@ -53,13 +53,7 @@ public class Feed {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof Feed)) {
-      return false;
-    }
-    Feed feed = (Feed) o;
+    if (!(o instanceof Feed feed)) return false;
     return getType() == feed.getType() && Objects.equals(getUserId(), feed.getUserId());
   }
 

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/media/MediaTrackType.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/media/MediaTrackType.java
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.chats.core.infrastructure.videoserver.data.media;
+
+public enum MediaTrackType {
+  AUDIO("a"),
+  VIDEO_OUT("vo"),
+  VIDEO_IN("vi"),
+  SCREEN("s");
+
+  private final String type;
+
+  MediaTrackType(String type) {
+    this.type = type;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public static MediaTrackType fromString(String type) {
+    for (MediaTrackType mediaTrackType : MediaTrackType.values()) {
+      if (mediaTrackType.getType().equalsIgnoreCase(type)) {
+        return mediaTrackType;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value: " + type);
+  }
+}

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/media/MediaType.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/media/MediaType.java
@@ -5,5 +5,7 @@
 package com.zextras.carbonio.chats.core.infrastructure.videoserver.data.media;
 
 public enum MediaType {
-  VIDEO, SCREEN
+  AUDIO,
+  VIDEO,
+  SCREEN
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/media/UserFeed.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/media/UserFeed.java
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.chats.core.infrastructure.videoserver.data.media;
+
+import java.util.Objects;
+
+public class UserFeed {
+
+  private MediaTrackType mediaTrackType;
+  private String userId;
+  private String meetingId;
+
+  public static UserFeed create() {
+    return new UserFeed();
+  }
+
+  public MediaTrackType getMediaTrackType() {
+    return mediaTrackType;
+  }
+
+  public UserFeed mediaTrackType(MediaTrackType mediaTrackType) {
+    this.mediaTrackType = mediaTrackType;
+    return this;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public UserFeed userId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  public String getMeetingId() {
+    return meetingId;
+  }
+
+  public UserFeed meetingId(String meetingId) {
+    this.meetingId = meetingId;
+    return this;
+  }
+
+  public static UserFeed fromString(String opaqueId) {
+    String[] userFeedId = opaqueId.split("/");
+    if (userFeedId.length != 3) {
+      return UserFeed.create();
+    }
+    return UserFeed.create()
+        .mediaTrackType(MediaTrackType.fromString(userFeedId[0]))
+        .userId(userFeedId[1])
+        .meetingId(userFeedId[2]);
+  }
+
+  @Override
+  public String toString() {
+    return mediaTrackType.getType() + "/" + userId + "/" + meetingId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof UserFeed userFeed)) return false;
+    return getMediaTrackType() == userFeed.getMediaTrackType()
+        && Objects.equals(getUserId(), userFeed.getUserId())
+        && Objects.equals(getMeetingId(), userFeed.getMeetingId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getMediaTrackType(), getUserId(), getMeetingId());
+  }
+}

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/request/VideoServerMessageRequest.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/data/request/VideoServerMessageRequest.java
@@ -25,6 +25,7 @@ import java.util.Objects;
  *       file
  *   <li>jsep: (optional) SDP offer to negotiate a new PeerConnection or SDP answer to close the
  *       circle and complete the setup of the PeerConnection
+ *   <li>opaque_id: a string you can use to link useful info like user-id
  * </ul>
  *
  * @see <a href="https://janus.conf.meetecho.com/docs/rest.html">JanusRestApi</a>
@@ -50,6 +51,8 @@ public class VideoServerMessageRequest {
 
   @JsonProperty("jsep")
   private RtcSessionDescription rtcSessionDescription;
+
+  private String opaqueId;
 
   public static VideoServerMessageRequest create() {
     return new VideoServerMessageRequest();
@@ -111,15 +114,24 @@ public class VideoServerMessageRequest {
     return this;
   }
 
+  public String getOpaqueId() {
+    return opaqueId;
+  }
+
+  public VideoServerMessageRequest opaqueId(String opaqueId) {
+    this.opaqueId = opaqueId;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
     if (!(o instanceof VideoServerMessageRequest that)) return false;
     return Objects.equals(getMessageRequest(), that.getMessageRequest())
         && Objects.equals(getPluginName(), that.getPluginName())
         && Objects.equals(getVideoServerPluginRequest(), that.getVideoServerPluginRequest())
         && Objects.equals(getApiSecret(), that.getApiSecret())
-        && Objects.equals(getRtcSessionDescription(), that.getRtcSessionDescription());
+        && Objects.equals(getRtcSessionDescription(), that.getRtcSessionDescription())
+        && Objects.equals(getOpaqueId(), that.getOpaqueId());
   }
 
   @Override
@@ -129,6 +141,7 @@ public class VideoServerMessageRequest {
         getPluginName(),
         getVideoServerPluginRequest(),
         getApiSecret(),
-        getRtcSessionDescription());
+        getRtcSessionDescription(),
+        getOpaqueId());
   }
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/AttachmentService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/AttachmentService.java
@@ -23,7 +23,7 @@ public interface AttachmentService {
    *
    * @param fileId identifier of attachment file to delete {@link UUID}
    * @param currentUser current authenticated user {@link UserPrincipal}
-   * @return The attachment file requested {@link InputStream}
+   * @return Content and meta data of yhe attachment file requested {@link FileContentAndMetadata}
    */
   FileContentAndMetadata getAttachmentById(UUID fileId, UserPrincipal currentUser);
 
@@ -55,7 +55,7 @@ public interface AttachmentService {
    * @param roomId identifier of the room attachment {@link UUID}
    * @param file file stream to save {@link InputStream}
    * @param mimeType file mime type
-   * @param contentLength file size
+   * @param contentLength file content length
    * @param fileName file name
    * @param description file description
    * @param messageId identifier of XMPP message to create

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/security/EventsWebSocketAuthenticationFilter.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/security/EventsWebSocketAuthenticationFilter.java
@@ -45,6 +45,7 @@ public class EventsWebSocketAuthenticationFilter implements Filter {
             .findAny()
             .map(Cookie::getValue);
     if (authToken.isEmpty()) {
+      ChatsLogger.warn("Websocket authentication failed with an empty token");
       HttpServletResponse httpServletResponse = (HttpServletResponse) response;
       httpServletResponse.setStatus(401);
       return;

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/EventsWebSocketEndpointConfigurator.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/EventsWebSocketEndpointConfigurator.java
@@ -11,16 +11,16 @@ import jakarta.websocket.server.ServerEndpointConfig;
 
 public class EventsWebSocketEndpointConfigurator extends ServerEndpointConfig.Configurator {
 
-  private final EventsWebSocketEndpoint eventsWebSocketEndpoint;
+  private final EventsWebSocketManager eventsWebSocketManager;
 
-  public EventsWebSocketEndpointConfigurator(EventsWebSocketEndpoint eventsWebSocketEndpoint) {
-    this.eventsWebSocketEndpoint = eventsWebSocketEndpoint;
+  public EventsWebSocketEndpointConfigurator(EventsWebSocketManager eventsWebSocketManager) {
+    this.eventsWebSocketManager = eventsWebSocketManager;
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public <T> T getEndpointInstance(Class<T> clazz) {
-    return (T) eventsWebSocketEndpoint;
+    return (T) eventsWebSocketManager;
   }
 
   @Override

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/EventsWebSocketManager.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/EventsWebSocketManager.java
@@ -7,13 +7,13 @@ package com.zextras.carbonio.chats.core.web.socket;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.rabbitmq.client.BuiltinExchangeType;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DeliverCallback;
 import com.zextras.carbonio.chats.core.exception.NotFoundException;
 import com.zextras.carbonio.chats.core.logging.ChatsLogger;
 import com.zextras.carbonio.chats.core.service.ParticipantService;
 import jakarta.servlet.http.HttpSession;
-import jakarta.websocket.EncodeException;
 import jakarta.websocket.OnClose;
 import jakarta.websocket.OnError;
 import jakarta.websocket.OnMessage;
@@ -29,59 +29,67 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Singleton
 @ServerEndpoint(value = "/events")
-public class EventsWebSocketEndpoint {
+public class EventsWebSocketManager {
 
   private static final String PING = "ping";
   private static final String PONG = "pong";
+
+  private static final String USER_ROUTING_KEY = "user-events";
+
   private final Map<String, String> consumerTagMap;
   private final Channel channel;
   private final ObjectMapper objectMapper;
   private final ParticipantService participantService;
 
   @Inject
-  public EventsWebSocketEndpoint(
+  public EventsWebSocketManager(
       Channel channel, ObjectMapper objectMapper, ParticipantService participantService) {
     this.channel = channel;
     this.objectMapper = objectMapper;
     this.participantService = participantService;
     this.consumerTagMap = new ConcurrentHashMap<>();
+    Runtime.getRuntime()
+        .addShutdownHook(new Thread(this::stop, "Event websocket manager shutdown hook"));
   }
 
   @OnOpen
-  public void onOpen(Session session) throws IOException, EncodeException {
+  public void onOpen(Session session) throws IOException {
+    SessionPingManager.add(session);
+
     UUID userId = UUID.fromString(getUserIdFromSession(session));
     UUID queueId = UUID.fromString(session.getId());
     String userQueue = userId + "/" + queueId;
-    session.setMaxIdleTimeout(0L);
     session
-        .getBasicRemote()
+        .getAsyncRemote()
         .sendObject(objectMapper.writeValueAsString(SessionOutEvent.create(queueId)));
     if (channel == null || !channel.isOpen()) {
       ChatsLogger.error(
           String.format(
-              "Unable to open session %s: event websocket handler channel is not up!", queueId));
+              "Unable to open websocket session %s: event websocket manager channel is not up!",
+              queueId));
       return;
     }
     try {
-      channel.queueDeclare(userQueue, false, false, true, null);
-      channel.exchangeDeclare(userId.toString(), "direct");
-      channel.queueBind(userQueue, userId.toString(), "");
+      channel.exchangeDeclare(userId.toString(), BuiltinExchangeType.DIRECT, false, false, null);
+      channel.queueDeclare(queueId.toString(), false, false, true, null);
+      channel.queueBind(queueId.toString(), userId.toString(), USER_ROUTING_KEY);
       DeliverCallback deliverCallback =
           (consumerTag, delivery) -> {
             String message = new String(delivery.getBody(), StandardCharsets.UTF_8);
             try {
               if (session.isOpen()) {
-                session.getBasicRemote().sendObject(message);
+                session.getAsyncRemote().sendObject(message);
               }
-            } catch (EncodeException | IOException e) {
+            } catch (Exception e) {
               ChatsLogger.warn(
                   String.format(
                       "Error sending event message to websocket for user/queue '%s'%nMessage: '%s'",
                       userQueue, message));
             }
           };
-      String tag = channel.basicConsume(userQueue, true, deliverCallback, consumerTag -> {});
-      consumerTagMap.put(session.getId(), tag);
+      String tag =
+          channel.basicConsume(queueId.toString(), true, deliverCallback, consumerTag -> {});
+      consumerTagMap.put(queueId.toString(), tag);
     } catch (Exception e) {
       ChatsLogger.warn(
           String.format("Error interacting with message broker for user/queue '%s'", userQueue));
@@ -90,14 +98,17 @@ public class EventsWebSocketEndpoint {
 
   @OnMessage
   public void onMessage(Session session, String message) {
+    if (message == null || message.isBlank()) return;
+
     try {
-      if (objectMapper.readValue(message, PingPongDtoEvent.class).getType().equals(PING)
-          && session.isOpen()) {
+      PingPongDtoEvent event = objectMapper.readValue(message, PingPongDtoEvent.class);
+      if (PING.equals(event.getType()) && session.isOpen()) {
         session
-            .getBasicRemote()
+            .getAsyncRemote()
             .sendObject(objectMapper.writeValueAsString(PingPongDtoEvent.create()));
       }
     } catch (Exception e) {
+      SessionPingManager.remove(session);
       UUID userId = UUID.fromString(getUserIdFromSession(session));
       UUID queueId = UUID.fromString(session.getId());
       String userQueue = userId + "/" + queueId;
@@ -107,15 +118,16 @@ public class EventsWebSocketEndpoint {
 
   @OnClose
   public void onClose(Session session) {
+    SessionPingManager.remove(session);
     closeSession(session);
   }
 
   @OnError
   public void onError(Session session, Throwable throwable) {
+    SessionPingManager.remove(session);
     UUID userId = UUID.fromString(getUserIdFromSession(session));
     UUID queueId = UUID.fromString(session.getId());
     String userQueue = userId + "/" + queueId;
-    closeSession(session);
     try {
       session.close();
     } catch (Exception e) {
@@ -137,34 +149,65 @@ public class EventsWebSocketEndpoint {
     String sessionId = session.getId();
     UUID queueId = UUID.fromString(sessionId);
     String userQueue = userId + "/" + queueId;
+
+    participantService.removeMeetingParticipant(queueId);
+
     if (channel == null || !channel.isOpen()) {
       ChatsLogger.error(
           String.format(
-              "Unable to close session %s: event websocket handler channel is not up!", queueId));
+              "Unable to close websocket session %s: event websocket handler channel is not up!",
+              queueId));
       return;
     }
-    basicCancel(sessionId, userQueue);
-    queueDeleteNoWait(userQueue);
-    participantService.removeMeetingParticipant(queueId);
+
+    queueConsumerCleanup(userQueue, queueId.toString(), userId.toString());
   }
 
-  private void queueDeleteNoWait(String userQueue) {
-    try {
-      channel.queueDeleteNoWait(userQueue, false, false);
-    } catch (Exception e) {
-      ChatsLogger.warn(String.format("Error deleting queue for user/queue '%s'", userQueue), e);
+  private void queueConsumerCleanup(String userQueue, String queueId, String userId) {
+    if (channel != null && channel.isOpen()) {
+      basicCancel(queueId, userQueue);
+      queueUnBind(userQueue, queueId, userId);
+      queueDeleteNoWait(userQueue, queueId);
     }
   }
 
-  private void basicCancel(String sessionId, String userQueue) {
-    String tag = consumerTagMap.remove(sessionId);
+  private void basicCancel(String queueId, String userQueue) {
+    String tag = consumerTagMap.get(queueId);
     if (tag != null) {
       try {
         channel.basicCancel(tag);
+        consumerTagMap.remove(queueId);
       } catch (Exception e) {
-        ChatsLogger.warn(
-                String.format("Error cancelling consumer for user/queue '%s'", userQueue), e);
+        ChatsLogger.warn(String.format("Error cancelling consumer for user/queue '%s'", userQueue));
       }
+    }
+  }
+
+  private void queueUnBind(String userQueue, String queueId, String userId) {
+    try {
+      channel.queueUnbind(queueId, userId, USER_ROUTING_KEY);
+    } catch (Exception e) {
+      ChatsLogger.warn(
+          String.format("Error unbinding queue from exchange for user/queue '%s'", userQueue));
+    }
+  }
+
+  private void queueDeleteNoWait(String userQueue, String queueId) {
+    try {
+      channel.queueDeleteNoWait(queueId, false, false);
+    } catch (Exception e) {
+      ChatsLogger.warn(String.format("Error deleting queue for user/queue '%s'", userQueue));
+    }
+  }
+
+  public void stop() {
+    try {
+      if (channel != null && channel.isOpen()) {
+        channel.close();
+        ChatsLogger.info("Event websocket manager channel closed successfully.");
+      }
+    } catch (Exception e) {
+      ChatsLogger.error("Error during stopping event websocket manager", e);
     }
   }
 

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/SessionPingManager.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/SessionPingManager.java
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.chats.core.web.socket;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Scheduler;
+import com.zextras.carbonio.chats.core.logging.ChatsLogger;
+import jakarta.websocket.PongMessage;
+import jakarta.websocket.Session;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class SessionPingManager {
+
+  private static final int PING_INTERVAL = 15;
+  private static final int THREAD_POOL_SIZE = 100;
+
+  private static final ScheduledExecutorService scheduler =
+      Executors.newScheduledThreadPool(THREAD_POOL_SIZE);
+
+  private static final Cache<Session, Long> sessionCache =
+      Caffeine.newBuilder()
+          .expireAfterWrite(60, TimeUnit.SECONDS)
+          .scheduler(Scheduler.systemScheduler())
+          .removalListener(
+              (session, timestamp, cause) -> {
+                if ((RemovalCause.EXPIRED.equals(cause) || RemovalCause.EXPLICIT.equals(cause))
+                    && session != null) {
+                  Session s = (Session) session;
+                  closeSession(s);
+                }
+              })
+          .build();
+
+  private SessionPingManager() {
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(SessionPingManager::shutdown, "Session ping manager shutdown hook"));
+  }
+
+  public static void add(Session session) {
+    session.addMessageHandler(
+        PongMessage.class,
+        pongMessage -> {
+          sessionCache.put(session, System.currentTimeMillis());
+        });
+
+    scheduler.scheduleAtFixedRate(
+        () -> {
+          if (session.isOpen()) {
+            try {
+              session
+                  .getAsyncRemote()
+                  .sendPing(ByteBuffer.wrap("ping".getBytes(StandardCharsets.UTF_8)));
+            } catch (IOException e) {
+              ChatsLogger.warn("Error sending ping to websocket session " + session.getId());
+              sessionCache.invalidate(session);
+            }
+          }
+        },
+        0,
+        PING_INTERVAL,
+        TimeUnit.SECONDS);
+    sessionCache.put(session, System.currentTimeMillis());
+  }
+
+  private static void closeSession(Session session) {
+    if (session.isOpen()) {
+      try {
+        session.close();
+      } catch (IOException e) {
+        ChatsLogger.warn("Error closing websocket session: " + session.getId(), e);
+      }
+    }
+  }
+
+  public static void remove(Session session) {
+    sessionCache.invalidate(session);
+  }
+
+  public static void shutdown() {
+    sessionCache.invalidateAll();
+    scheduler.shutdownNow();
+  }
+}

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/VideoServerEventListener.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/socket/VideoServerEventListener.java
@@ -4,18 +4,14 @@
 
 package com.zextras.carbonio.chats.core.web.socket;
 
-import static io.vavr.API.$;
-import static io.vavr.API.Case;
-import static io.vavr.API.Match;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.rabbitmq.client.BuiltinExchangeType;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DeliverCallback;
 import com.rabbitmq.client.Recoverable;
 import com.rabbitmq.client.RecoveryListener;
-import com.zextras.carbonio.chats.core.cache.CacheHandler;
 import com.zextras.carbonio.chats.core.data.entity.VideoServerSession;
 import com.zextras.carbonio.chats.core.data.event.MeetingAudioAnswered;
 import com.zextras.carbonio.chats.core.data.event.MeetingMediaStreamChanged;
@@ -26,14 +22,16 @@ import com.zextras.carbonio.chats.core.data.event.MeetingSdpOffered;
 import com.zextras.carbonio.chats.core.exception.EventDispatcherException;
 import com.zextras.carbonio.chats.core.infrastructure.event.EventDispatcher;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.VideoServerService;
+import com.zextras.carbonio.chats.core.infrastructure.videoserver.data.event.EventData;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.data.event.StreamData;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.data.event.VideoServerEvent;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.data.media.Feed;
+import com.zextras.carbonio.chats.core.infrastructure.videoserver.data.media.MediaTrackType;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.data.media.MediaType;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.data.media.RtcSessionDescription;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.data.media.SubscribedStream;
+import com.zextras.carbonio.chats.core.infrastructure.videoserver.data.media.UserFeed;
 import com.zextras.carbonio.chats.core.logging.ChatsLogger;
-import io.vavr.MatchError;
 import jakarta.validation.constraints.NotNull;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -45,7 +43,8 @@ import java.util.UUID;
 public class VideoServerEventListener {
 
   private static final String JANUS_EXCHANGE = "janus-exchange";
-  private static final String JANUS_EVENTS = "janus-events";
+  private static final String JANUS_QUEUE = "janus-queue";
+  private static final String JANUS_ROUTING_KEY = "janus-events";
 
   private static final String LOCAL = "local";
   private static final String TALKING = "talking";
@@ -57,30 +56,25 @@ public class VideoServerEventListener {
   private static final int JSEP_TYPE = 8;
   private static final int PLUGIN_TYPE = 64;
 
+  private volatile String consumerTag;
+
   private final Channel channel;
   private final EventDispatcher eventDispatcher;
   private final ObjectMapper objectMapper;
   private final VideoServerService videoServerService;
-  private final CacheHandler cacheHandler;
-
-  private enum EventType {
-    AUDIO,
-    VIDEO,
-    SCREEN
-  }
 
   @Inject
   public VideoServerEventListener(
       Channel channel,
       EventDispatcher eventDispatcher,
       ObjectMapper objectMapper,
-      VideoServerService videoServerService,
-      CacheHandler cacheHandler) {
+      VideoServerService videoServerService) {
     this.channel = getRecoverableChannel(channel);
     this.eventDispatcher = eventDispatcher;
     this.objectMapper = objectMapper;
     this.videoServerService = videoServerService;
-    this.cacheHandler = cacheHandler;
+    Runtime.getRuntime()
+        .addShutdownHook(new Thread(this::stop, "Video server event listener shutdown hook"));
   }
 
   private @NotNull Channel getRecoverableChannel(Channel channel) {
@@ -106,195 +100,186 @@ public class VideoServerEventListener {
       throw new EventDispatcherException("Video server event listener channel is not up!");
     }
     try {
-      channel.queueDeclare(JANUS_EVENTS, false, false, false, null);
-      channel.exchangeDeclare(JANUS_EXCHANGE, "direct");
-      channel.queueBind(JANUS_EVENTS, JANUS_EXCHANGE, JANUS_EVENTS);
+      channel.exchangeDeclare(JANUS_EXCHANGE, BuiltinExchangeType.DIRECT, false);
+      channel.queueDeclare(JANUS_QUEUE, false, false, false, null);
+      channel.queueBind(JANUS_QUEUE, JANUS_EXCHANGE, JANUS_ROUTING_KEY);
       DeliverCallback deliverCallback = createDeliveryCallBack();
-      channel.basicConsume(JANUS_EVENTS, true, deliverCallback, consumerTag -> this.start());
+      consumerTag = channel.basicConsume(JANUS_QUEUE, true, deliverCallback, tag -> {});
     } catch (Exception e) {
-      ChatsLogger.error("Error during processing video server events ", e);
+      ChatsLogger.error("Error starting video server events processing", e);
+    }
+  }
+
+  public void stop() {
+    try {
+      if (channel != null && channel.isOpen()) {
+        if (consumerTag != null) {
+          channel.basicCancel(consumerTag);
+          ChatsLogger.info("Video server event listener consumer canceled successfully.");
+        }
+        channel.close();
+        ChatsLogger.info("Video server event listener channel closed successfully.");
+      }
+    } catch (Exception e) {
+      ChatsLogger.error("Error during stopping video server event listener", e);
     }
   }
 
   private @NotNull DeliverCallback createDeliveryCallBack() {
-    return (consumerTag, delivery) -> {
+    return (tag, delivery) -> {
       String message = new String(delivery.getBody(), StandardCharsets.UTF_8);
-      VideoServerEvent videoServerEvent = objectMapper.readValue(message, VideoServerEvent.class);
-      switch (videoServerEvent.getType()) {
-        case JSEP_TYPE:
-          handleJsepTypeEvent(videoServerEvent);
-          break;
-        case PLUGIN_TYPE:
-          handleAudioBridgeEvent(videoServerEvent);
-          handleStreamsEvent(videoServerEvent);
-          break;
-        default:
-          break;
+      VideoServerEvent event = objectMapper.readValue(message, VideoServerEvent.class);
+
+      switch (event.getType()) {
+        case JSEP_TYPE -> handleJsepTypeEvent(event);
+        case PLUGIN_TYPE -> handlePluginTypeEvent(event);
+        default -> {
+          /*just ignore other events*/
+        }
       }
     };
   }
 
-  private void handleJsepTypeEvent(VideoServerEvent videoServerEvent) {
-    Optional.ofNullable(videoServerEvent.getEventInfo().getOwner())
-        .ifPresent(
-            owner -> {
-              if (LOCAL.equalsIgnoreCase(owner)) {
-                VideoServerSession videoServerSession =
-                    cacheHandler
-                        .getVideoServerSessionCache()
-                        .get(
-                            String.valueOf(videoServerEvent.getSessionId()),
-                            this::fetchVideoServerSession);
-                if (videoServerSession != null) {
-                  processRtcSessionDescription(videoServerEvent, videoServerSession);
-                }
-              }
-            });
-  }
+  private void handlePluginTypeEvent(VideoServerEvent event) {
+    EventData data = event.getEventInfo().getEventData();
 
-  private VideoServerSession fetchVideoServerSession(String sessionId) {
-    return videoServerService.getSession(sessionId).orElse(null);
-  }
+    if (data.getAudioBridge() != null) {
+      handleAudioBridgeEvent(event);
+    }
 
-  private void processRtcSessionDescription(
-      VideoServerEvent videoServerEvent, VideoServerSession videoServerSession) {
-    try {
-      EventType eventType =
-          Match(videoServerEvent.getHandleId().toString())
-              .of(
-                  Case($(videoServerSession.getAudioHandleId()), EventType.AUDIO),
-                  Case($(videoServerSession.getVideoInHandleId()), EventType.VIDEO),
-                  Case($(videoServerSession.getVideoOutHandleId()), EventType.VIDEO),
-                  Case($(videoServerSession.getScreenHandleId()), EventType.SCREEN));
-      RtcSessionDescription rtcSessionDescription =
-          videoServerEvent.getEventInfo().getRtcSessionDescription();
-      switch (rtcSessionDescription.getType()) {
-        case OFFER:
-          eventDispatcher.sendToUserExchange(
-              videoServerSession.getUserId(),
-              MeetingSdpOffered.create()
-                  .meetingId(UUID.fromString(videoServerSession.getId().getMeetingId()))
-                  .userId(UUID.fromString(videoServerSession.getUserId()))
-                  .mediaType(eventType == EventType.VIDEO ? MediaType.VIDEO : MediaType.SCREEN)
-                  .sdp(rtcSessionDescription.getSdp()));
-          break;
-        case ANSWER:
-          switch (eventType) {
-            case AUDIO:
-              eventDispatcher.sendToUserExchange(
-                  videoServerSession.getUserId(),
-                  MeetingAudioAnswered.create()
-                      .meetingId(UUID.fromString(videoServerSession.getId().getMeetingId()))
-                      .userId(UUID.fromString(videoServerSession.getUserId()))
-                      .sdp(rtcSessionDescription.getSdp()));
-              break;
-            case VIDEO, SCREEN:
-              eventDispatcher.sendToUserExchange(
-                  videoServerSession.getUserId(),
-                  MeetingSdpAnswered.create()
-                      .meetingId(UUID.fromString(videoServerSession.getId().getMeetingId()))
-                      .userId(UUID.fromString(videoServerSession.getUserId()))
-                      .mediaType(eventType == EventType.VIDEO ? MediaType.VIDEO : MediaType.SCREEN)
-                      .sdp(rtcSessionDescription.getSdp()));
-              break;
-            default:
-              break;
-          }
-          break;
-        default:
-          break;
-      }
-    } catch (MatchError m) {
-      ChatsLogger.warn("Invalid event handle id: " + m.getObject());
+    if (data.getEvent() != null) {
+      handleStreamsEvent(event);
     }
   }
 
-  private void handleAudioBridgeEvent(VideoServerEvent videoServerEvent) {
-    Optional.ofNullable(videoServerEvent.getEventInfo().getEventData().getAudioBridge())
-        .ifPresent(
-            eventType -> {
-              if (TALKING.equals(eventType) || STOPPED_TALKING.equals(eventType)) {
-                String meetingId =
-                    videoServerEvent.getEventInfo().getEventData().getRoom().split("_")[1];
-                List<String> sessionUserIds = getMeetingVideoServerSessions(meetingId);
-                eventDispatcher.sendToUserExchange(
-                    sessionUserIds,
-                    MeetingParticipantTalking.create()
-                        .meetingId(UUID.fromString(meetingId))
-                        .userId(
-                            UUID.fromString(videoServerEvent.getEventInfo().getEventData().getId()))
-                        .isTalking(
-                            TALKING.equals(
-                                videoServerEvent.getEventInfo().getEventData().getAudioBridge())));
-              }
-            });
+  private void handleJsepTypeEvent(VideoServerEvent event) {
+    String owner = event.getEventInfo().getOwner();
+    if (!LOCAL.equalsIgnoreCase(owner)) return;
+
+    UserFeed userFeed = UserFeed.fromString(event.getOpaqueId());
+    RtcSessionDescription rtc = event.getEventInfo().getRtcSessionDescription();
+
+    if (rtc == null) return;
+
+    UUID meetingId = UUID.fromString(userFeed.getMeetingId());
+    UUID userId = UUID.fromString(userFeed.getUserId());
+    MediaType mediaType = mapEventType(userFeed.getMediaTrackType());
+
+    switch (rtc.getType()) {
+      case OFFER ->
+          eventDispatcher.sendToUserExchange(
+              userFeed.getUserId(),
+              MeetingSdpOffered.create()
+                  .meetingId(meetingId)
+                  .userId(userId)
+                  .mediaType(mediaType)
+                  .sdp(rtc.getSdp()));
+
+      case ANSWER -> dispatchAnswerEvent(userFeed, rtc.getSdp(), mediaType);
+    }
   }
 
-  private void handleStreamsEvent(VideoServerEvent videoServerEvent) {
-    Optional.ofNullable(videoServerEvent.getEventInfo().getEventData().getEvent())
-        .ifPresent(
-            eventType -> {
-              switch (eventType) {
-                case SUBSCRIBING, UPDATED:
-                  handleUpdatedEvent(videoServerEvent);
-                  break;
-                case PUBLISHED:
-                  handlePublishedEvent(videoServerEvent);
-                  break;
-                default:
-                  break;
-              }
-            });
+  private void dispatchAnswerEvent(UserFeed userFeed, String sdp, MediaType mediaType) {
+    UUID meetingId = UUID.fromString(userFeed.getMeetingId());
+    UUID userId = UUID.fromString(userFeed.getUserId());
+
+    switch (mediaType) {
+      case AUDIO ->
+          eventDispatcher.sendToUserExchange(
+              userFeed.getUserId(),
+              MeetingAudioAnswered.create().meetingId(meetingId).userId(userId).sdp(sdp));
+
+      case VIDEO, SCREEN ->
+          eventDispatcher.sendToUserExchange(
+              userFeed.getUserId(),
+              MeetingSdpAnswered.create()
+                  .meetingId(meetingId)
+                  .userId(userId)
+                  .mediaType(mediaType)
+                  .sdp(sdp));
+    }
   }
 
-  private void handleUpdatedEvent(VideoServerEvent videoServerEvent) {
-    List<StreamData> streamDataList =
-        Optional.ofNullable(videoServerEvent.getEventInfo().getEventData().getStreamList())
+  private void handleAudioBridgeEvent(VideoServerEvent event) {
+    String audioBridgeEvent = event.getEventInfo().getEventData().getAudioBridge();
+    if (!TALKING.equals(audioBridgeEvent) && !STOPPED_TALKING.equals(audioBridgeEvent)) return;
+
+    UserFeed userFeed = UserFeed.fromString(event.getOpaqueId());
+    List<String> recipients = getMeetingVideoServerSessions(userFeed.getMeetingId());
+
+    eventDispatcher.sendToUserExchange(
+        recipients,
+        MeetingParticipantTalking.create()
+            .meetingId(UUID.fromString(userFeed.getMeetingId()))
+            .userId(UUID.fromString(userFeed.getUserId()))
+            .isTalking(TALKING.equals(audioBridgeEvent)));
+  }
+
+  private void handleStreamsEvent(VideoServerEvent event) {
+    EventData data = event.getEventInfo().getEventData();
+    switch (data.getEvent()) {
+      case SUBSCRIBING, UPDATED -> handleUpdatedEvent(event);
+      case PUBLISHED -> handlePublishedEvent(event);
+      default -> {
+        /*just ignore other events*/
+      }
+    }
+  }
+
+  private void handleUpdatedEvent(VideoServerEvent event) {
+    List<StreamData> streams =
+        Optional.ofNullable(event.getEventInfo().getEventData().getStreamList())
             .orElse(Collections.emptyList())
             .stream()
-            .filter(stream -> stream.getFeedId() != null)
+            .filter(s -> s.getFeedId() != null)
             .toList();
-    if (!streamDataList.isEmpty()) {
-      VideoServerSession videoServerSession =
-          cacheHandler
-              .getVideoServerSessionCache()
-              .get(String.valueOf(videoServerEvent.getSessionId()), this::fetchVideoServerSession);
-      if (videoServerSession != null) {
-        eventDispatcher.sendToUserExchange(
-            videoServerSession.getUserId(),
-            MeetingParticipantSubscribed.create()
-                .meetingId(UUID.fromString(videoServerSession.getId().getMeetingId()))
-                .userId(UUID.fromString(videoServerSession.getUserId()))
-                .streams(
-                    streamDataList.stream()
-                        .map(
-                            stream -> {
-                              Feed feed = Feed.fromString(stream.getFeedId());
-                              return SubscribedStream.create()
-                                  .type(feed.getType().toString().toLowerCase())
-                                  .userId(feed.getUserId())
-                                  .mid(stream.getMid());
-                            })
-                        .toList()));
-      }
-    }
+
+    if (streams.isEmpty()) return;
+
+    UserFeed userFeed = UserFeed.fromString(event.getOpaqueId());
+
+    eventDispatcher.sendToUserExchange(
+        userFeed.getUserId(),
+        MeetingParticipantSubscribed.create()
+            .meetingId(UUID.fromString(userFeed.getMeetingId()))
+            .userId(UUID.fromString(userFeed.getUserId()))
+            .streams(
+                streams.stream()
+                    .map(
+                        s -> {
+                          Feed f = Feed.fromString(s.getFeedId());
+                          return SubscribedStream.create()
+                              .type(f.getType().toString().toLowerCase())
+                              .userId(f.getUserId())
+                              .mid(s.getMid());
+                        })
+                    .toList()));
   }
 
-  private void handlePublishedEvent(VideoServerEvent videoServerEvent) {
-    Feed feed = Feed.fromString(videoServerEvent.getEventInfo().getEventData().getId());
-    String meetingId = videoServerEvent.getEventInfo().getEventData().getRoom().split("_")[1];
+  private void handlePublishedEvent(VideoServerEvent event) {
+    UserFeed userFeed = UserFeed.fromString(event.getOpaqueId());
+    MediaType mediaType = mapEventType(userFeed.getMediaTrackType());
+
     eventDispatcher.sendToUserExchange(
-        getMeetingVideoServerSessions(meetingId),
+        getMeetingVideoServerSessions(userFeed.getMeetingId()),
         MeetingMediaStreamChanged.create()
-            .meetingId(UUID.fromString(meetingId))
-            .userId(UUID.fromString(feed.getUserId()))
-            .mediaType(feed.getType())
-            .active(PUBLISHED.equals(videoServerEvent.getEventInfo().getEventData().getEvent())));
+            .meetingId(UUID.fromString(userFeed.getMeetingId()))
+            .userId(UUID.fromString(userFeed.getUserId()))
+            .mediaType(mediaType)
+            .active(PUBLISHED.equals(event.getEventInfo().getEventData().getEvent())));
   }
 
   private @NotNull List<String> getMeetingVideoServerSessions(String meetingId) {
     return videoServerService.getSessions(meetingId).stream()
         .map(VideoServerSession::getUserId)
         .toList();
+  }
+
+  private MediaType mapEventType(MediaTrackType mediaTrackType) {
+    return switch (mediaTrackType) {
+      case AUDIO -> MediaType.AUDIO;
+      case VIDEO_OUT, VIDEO_IN -> MediaType.VIDEO;
+      case SCREEN -> MediaType.SCREEN;
+    };
   }
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/utility/HttpClientProvider.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/utility/HttpClientProvider.java
@@ -26,7 +26,11 @@ public class HttpClientProvider {
   private static final CloseableHttpClient httpClient;
   private static final ScheduledExecutorService executor;
 
-  private HttpClientProvider() {}
+  private HttpClientProvider() {
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(HttpClientProvider::shutdown, "Http client provider shutdown hook"));
+  }
 
   static {
     connectionManager = new PoolingHttpClientConnectionManager(30, TimeUnit.SECONDS);
@@ -56,8 +60,6 @@ public class HttpClientProvider {
             .setKeepAliveStrategy((response, context) -> KEEP_ALIVE_SECONDS * 1000L)
             .setDefaultRequestConfig(requestConfig)
             .build();
-
-    Runtime.getRuntime().addShutdownHook(new Thread(HttpClientProvider::shutdown));
   }
 
   public static CloseableHttpClient getHttpClient() {
@@ -66,7 +68,7 @@ public class HttpClientProvider {
 
   public static void shutdown() {
     try {
-      ChatsLogger.info("Shutting down HttpClient...");
+      ChatsLogger.info("Shutting down HttpClientProvider...");
       httpClient.close();
       connectionManager.shutdown();
       executor.shutdown();

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/VideoServerServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/VideoServerServiceImplTest.java
@@ -287,7 +287,8 @@ class VideoServerServiceImplTest {
           VideoServerMessageRequest.create()
               .messageRequest("attach")
               .pluginName("janus.plugin.audiobridge")
-              .apiSecret("token"),
+              .apiSecret("token")
+              .opaqueId("meeting/a/" + meeting1Id.toString()),
           createAudioHandleMessageRequest);
       VideoServerMessageRequest createVideoHandleMessageRequest =
           createHandleRequestCaptor.getAllValues().get(1);
@@ -295,7 +296,8 @@ class VideoServerServiceImplTest {
           VideoServerMessageRequest.create()
               .messageRequest("attach")
               .pluginName("janus.plugin.videoroom")
-              .apiSecret("token"),
+              .apiSecret("token")
+              .opaqueId("meeting/v/" + meeting1Id.toString()),
           createVideoHandleMessageRequest);
 
       assertEquals(1, createAudioRoomRequestCaptor.getAllValues().size());
@@ -662,7 +664,8 @@ class VideoServerServiceImplTest {
           VideoServerMessageRequest.create()
               .messageRequest("attach")
               .pluginName("janus.plugin.audiobridge")
-              .apiSecret("token"),
+              .apiSecret("token")
+              .opaqueId("a/" + user1Id.toString() + "/" + meeting1Id.toString()),
           audioHandleMessageRequest);
       VideoServerMessageRequest videoOutHandleMessageRequest =
           createHandleRequestCaptor.getAllValues().get(1);
@@ -670,7 +673,8 @@ class VideoServerServiceImplTest {
           VideoServerMessageRequest.create()
               .messageRequest("attach")
               .pluginName("janus.plugin.videoroom")
-              .apiSecret("token"),
+              .apiSecret("token")
+              .opaqueId("vo/" + user1Id.toString() + "/" + meeting1Id.toString()),
           videoOutHandleMessageRequest);
       VideoServerMessageRequest videoInHandleMessageRequest =
           createHandleRequestCaptor.getAllValues().get(2);
@@ -678,7 +682,8 @@ class VideoServerServiceImplTest {
           VideoServerMessageRequest.create()
               .messageRequest("attach")
               .pluginName("janus.plugin.videoroom")
-              .apiSecret("token"),
+              .apiSecret("token")
+              .opaqueId("vi/" + user1Id.toString() + "/" + meeting1Id.toString()),
           videoInHandleMessageRequest);
       VideoServerMessageRequest screenHandleMessageRequest =
           createHandleRequestCaptor.getAllValues().get(3);
@@ -686,7 +691,8 @@ class VideoServerServiceImplTest {
           VideoServerMessageRequest.create()
               .messageRequest("attach")
               .pluginName("janus.plugin.videoroom")
-              .apiSecret("token"),
+              .apiSecret("token")
+              .opaqueId("s/" + user1Id.toString() + "/" + meeting1Id.toString()),
           screenHandleMessageRequest);
 
       assertEquals(1, joinPublisherVideoRequestCaptor.getAllValues().size());

--- a/carbonio-ws-collaboration-it/pom.xml
+++ b/carbonio-ws-collaboration-it/pom.xml
@@ -98,6 +98,11 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator-cdi</artifactId>
     </dependency>

--- a/carbonio-ws-collaboration-openapi/pom.xml
+++ b/carbonio-ws-collaboration-openapi/pom.xml
@@ -75,13 +75,6 @@ SPDX-License-Identifier: AGPL-3.0-only
       <artifactId>resteasy-jackson2-provider</artifactId>
     </dependency>
 
-    <!-- Jakarta -->
-    <dependency>
-      <groupId>jakarta.platform</groupId>
-      <artifactId>jakarta.jakartaee-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>
       <artifactId>jetty-ee10-servlet</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,9 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- Previewer -->
     <preview-sdk.version>1.0.2</preview-sdk.version>
     <!-- Jetty -->
-    <org.eclipse.jetty.version>12.0.14</org.eclipse.jetty.version>
-    <org.eclipse.jetty.servlet.version>12.0.14</org.eclipse.jetty.servlet.version>
-    <org.eclipse.jetty.websocket.version>12.0.14</org.eclipse.jetty.websocket.version>
+    <org.eclipse.jetty.version>12.0.19</org.eclipse.jetty.version>
+    <org.eclipse.jetty.servlet.version>12.0.19</org.eclipse.jetty.servlet.version>
+    <org.eclipse.jetty.websocket.version>12.0.19</org.eclipse.jetty.websocket.version>
     <!-- Guice -->
     <com.google.inject.version>7.0.0</com.google.inject.version>
     <!-- Rest easy -->
@@ -62,8 +62,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     <jakarta.ws.rs.version>4.0.0</jakarta.ws.rs.version>
     <!-- Ebean -->
     <io.ebean.version>15.6.0</io.ebean.version>
-    <!-- Jakarta api -->
-    <jakarta.api.version>10.0.0</jakarta.api.version>
     <!-- Database -->
     <org.flywaydb.version>10.19.0</org.flywaydb.version>
     <com.zaxxer.HikariCP.version>6.0.0</com.zaxxer.HikariCP.version>
@@ -87,7 +85,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- Rabbit MQ -->
     <com.rabbitmq.amqp-client.version>5.22.0</com.rabbitmq.amqp-client.version>
     <!-- Web Socket -->
-    <jakarta.websocket-api.version>2.0.0</jakarta.websocket-api.version>
+    <jakarta.websocket-api.version>2.1.1</jakarta.websocket-api.version>
     <jakarta.el>5.0.0-M1</jakarta.el>
     <!-- Cache -->
     <caffeine.cache.version>3.1.8</caffeine.cache.version>
@@ -148,44 +146,20 @@ SPDX-License-Identifier: AGPL-3.0-only
       </dependency>
 
       <dependency>
-        <groupId>org.eclipse.jetty.websocket</groupId>
-        <artifactId>websocket-jakarta-server</artifactId>
-        <version>${org.eclipse.jetty.websocket.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.mortbay.jasper</groupId>
-            <artifactId>apache-el</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
         <version>${org.eclipse.jetty.websocket.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.mortbay.jasper</groupId>
-            <artifactId>apache-el</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
-        <artifactId>jetty-ee10-websocket-jakarta-client</artifactId>
-        <version>${org.eclipse.jetty.websocket.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.mortbay.jasper</groupId>
-            <artifactId>apache-el</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>jakarta.websocket</groupId>
         <artifactId>jakarta.websocket-api</artifactId>
+        <version>${jakarta.websocket-api.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>jakarta.websocket</groupId>
+        <artifactId>jakarta.websocket-client-api</artifactId>
         <version>${jakarta.websocket-api.version}</version>
       </dependency>
 
@@ -267,13 +241,6 @@ SPDX-License-Identifier: AGPL-3.0-only
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator-cdi</artifactId>
         <version>${org.hibernate.validator.version}</version>
-      </dependency>
-
-      <!-- Jakarta -->
-      <dependency>
-        <groupId>jakarta.platform</groupId>
-        <artifactId>jakarta.jakartaee-api</artifactId>
-        <version>${jakarta.api.version}</version>
       </dependency>
 
       <!-- Ebean dependencies -->


### PR DESCRIPTION
* chore: add opaque-id to video server requests
* chore: use user-events routing-key to dispatch events
* chore: remove video server session cache
* chore: refactor Boot
* chore: remove jetty unused dependency
* chore: use BufferOutputStream in FileContentAndMetadata

feat: implement new SessionPingManager to keep alive websockets

* chore: upgrade jetty dependencies versions to 12.0.19
* chore: set 30 seconds for websockets timeout on Boot
* chore: improve EventWebSocketManager using asyncRemote
* chore: remove close session actions from onError in EventWebsocketManager

ref: WSC-1873