### PR TITLE
chore: update jenkins library versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-  identifier: 'jenkins-packages-build-library@1.0.4',
+  identifier: 'jenkins-lib-common@1.1.2',
   retriever: modernSCM([
     $class: 'GitSCMSource',
-    remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
-    credentialsId: 'jenkins-integration-with-github-account'
+    credentialsId: 'jenkins-integration-with-github-account',
+    remote: 'git@github.com:zextras/jenkins-lib-common.git',
   ])
 )
 
@@ -26,24 +26,18 @@ pipeline {
 
   parameters {
     booleanParam defaultValue: false,
-      description: 'Whether to upload the packages in playground repository',
-      name: 'PLAYGROUND'
-    booleanParam defaultValue: false,
       description: 'Whether to run the dependency check',
       name: 'DEPENDENCY_CHECK'
   }
 
-  tools {
-    jfrog 'jfrog-cli'
-  }
-
   stages {
-    stage('Build setup') {
+    stage('Setup') {
       steps {
         container('jdk-21') {
           checkout scm
           script {
             gitMetadata()
+            properties(defaultPipelineProperties())
           }
         }
       }
@@ -139,9 +133,15 @@ pipeline {
     }
 
     stage('Upload artifacts') {
+      when {
+        expression { return uploadStage.shouldUpload() }
+      }
+      tools {
+        jfrog 'jfrog-cli'
+      }
       steps {
         uploadStage(
-          packages: yapHelper.getPackageNames(),
+          packages: yapHelper.resolvePackageNames(),
           rockySinglePkg: true,
           ubuntuSinglePkg: true,
         )


### PR DESCRIPTION
## Summary

Updates Jenkins library to jenkins-lib-common@1.1.2 with improvements and best practices.

## Changes Applied

- Library declaration updated from jenkins-packages-build-library@1.0.4 to jenkins-lib-common@1.1.2
- Credentials configuration reordered (credentialsId before remote)
- PLAYGROUND parameter removed
- Build setup stage renamed to Setup with gitMetadata() and defaultPipelineProperties()
- JFrog tool declaration moved to Upload artifacts stage
- yapHelper.getPackageNames() updated to resolvePackageNames()

## References

- [jenkins-lib-common CHANGELOG](https://github.com/zextras/jenkins-lib-common/blob/main/CHANGELOG.md)