### PR TITLE
chore(ci): update jenkins library pipeline configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-  identifier: 'jenkins-packages-build-library@1.0.4',
+  identifier: 'jenkins-lib-common@1.1.2',
   retriever: modernSCM([
     $class: 'GitSCMSource',
-    remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
-    credentialsId: 'jenkins-integration-with-github-account'
+    credentialsId: 'jenkins-integration-with-github-account',
+    remote: 'git@github.com:zextras/jenkins-lib-common.git',
   ])
 )
 
@@ -26,24 +26,18 @@ pipeline {
 
   parameters {
     booleanParam defaultValue: false,
-      description: 'Whether to upload the packages in playground repository',
-      name: 'PLAYGROUND'
-    booleanParam defaultValue: false,
       description: 'Whether to run the dependency check',
       name: 'DEPENDENCY_CHECK'
   }
 
-  tools {
-    jfrog 'jfrog-cli'
-  }
-
   stages {
-    stage('Build setup') {
+    stage('Setup') {
       steps {
         container('jdk-21') {
           checkout scm
           script {
             gitMetadata()
+            properties(defaultPipelineProperties())
           }
         }
       }
@@ -139,9 +133,15 @@ pipeline {
     }
 
     stage('Upload artifacts') {
+      when {
+        expression { return uploadStage.shouldUpload() }
+      }
+      tools {
+        jfrog 'jfrog-cli'
+      }
       steps {
         uploadStage(
-          packages: yapHelper.getPackageNames(),
+          packages: yapHelper.resolvePackageNames(),
           rockySinglePkg: true,
           ubuntuSinglePkg: true,
         )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,8 @@ library(
   ])
 )
 
+properties(defaultPipelineProperties())
+
 pipeline {
   agent {
     node {
@@ -37,7 +39,6 @@ pipeline {
           checkout scm
           script {
             gitMetadata()
-            properties(defaultPipelineProperties())
           }
         }
       }


### PR DESCRIPTION
Applies Jenkins library improvements from spec files:

## Changes
- **default-pipeline-properties**: Moved `properties(defaultPipelineProperties())` from inside the Setup stage to top-level scope after library imports

This change ensures Jenkins pipeline properties are configured at the correct execution point in the pipeline lifecycle.

Refs: [IN-982](https://zextras.atlassian.net/browse/IN-982)

[IN-982]: https://zextras.atlassian.net/browse/IN-982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ