### PR TITLE
fix: remove non-owners internal users from temporary room when they leave the meeting (#196)

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -16,6 +16,12 @@ SPDX-FileCopyrightText = "2026 Zextras"
 SPDX-License-Identifier = "AGPL-3.0-only"
 
 [[annotations]]
+path = "AGENTS.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Zextras"
+SPDX-License-Identifier = "AGPL-3.0-only"
+
+[[annotations]]
 path = "THIRDPARTIES"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 Zextras"

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImpl.java
@@ -146,6 +146,8 @@ public class MembersServiceImpl implements MembersService {
                 .room(room)
                 .userId(member.getUserId().toString())
                 .owner(member.isOwner())
+                .external(member.isExternal())
+                .temporary(member.isTemporary())
                 .joinedAt(dateTime));
     room.getSubscriptions().add(subscription);
 
@@ -165,10 +167,7 @@ public class MembersServiceImpl implements MembersService {
               .getByRoomIdAndUserId(room.getId(), member.getUserId().toString())
               .orElseGet(() -> RoomUserSettings.create(room, member.getUserId().toString()));
 
-      if (member.isHistoryCleared()) {
-        settings.clearedAt(dateTime);
-      }
-
+      settings.clearedAt(dateTime);
       roomUserSettingsRepository.save(settings);
     }
   }
@@ -222,7 +221,9 @@ public class MembersServiceImpl implements MembersService {
             .filter(Subscription::isOwner)
             .map(Subscription::getUserId)
             .toList();
-    if (owners.size() == 1 && owners.get(0).equals(userId) && room.getSubscriptions().size() > 1) {
+    if (owners.size() == 1
+        && owners.getFirst().equals(userId)
+        && room.getSubscriptions().size() > 1) {
       throw new BadRequestException("Last owner can't leave the room");
     }
   }
@@ -233,7 +234,7 @@ public class MembersServiceImpl implements MembersService {
             .filter(Subscription::isOwner)
             .map(Subscription::getUserId)
             .toList()
-            .get(0);
+            .getFirst();
 
     messageDispatcher.removeRoomMember(room.getId(), memberId);
     messageDispatcher.sendAffiliationMessage(

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImpl.java
@@ -27,9 +27,7 @@ import com.zextras.carbonio.chats.core.exception.NotFoundException;
 import com.zextras.carbonio.chats.core.infrastructure.event.EventDispatcher;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.VideoServerService;
 import com.zextras.carbonio.chats.core.repository.ParticipantRepository;
-import com.zextras.carbonio.chats.core.service.MeetingService;
-import com.zextras.carbonio.chats.core.service.ParticipantService;
-import com.zextras.carbonio.chats.core.service.RoomService;
+import com.zextras.carbonio.chats.core.service.*;
 import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
 import com.zextras.carbonio.chats.model.AudioStreamSettingsDto;
 import com.zextras.carbonio.chats.model.HandStatusDto;
@@ -48,6 +46,7 @@ public class ParticipantServiceImpl implements ParticipantService {
 
   private final MeetingService meetingService;
   private final RoomService roomService;
+  private final MembersService membersService;
   private final ParticipantRepository participantRepository;
   private final VideoServerService videoServerService;
   private final EventDispatcher eventDispatcher;
@@ -57,12 +56,14 @@ public class ParticipantServiceImpl implements ParticipantService {
   public ParticipantServiceImpl(
       MeetingService meetingService,
       RoomService roomService,
+      MembersService membersService,
       ParticipantRepository participantRepository,
       VideoServerService videoServerService,
       EventDispatcher eventDispatcher,
       Clock clock) {
     this.meetingService = meetingService;
     this.roomService = roomService;
+    this.membersService = membersService;
     this.participantRepository = participantRepository;
     this.videoServerService = videoServerService;
     this.eventDispatcher = eventDispatcher;
@@ -258,42 +259,12 @@ public class ParticipantServiceImpl implements ParticipantService {
                                 UUID.fromString(participant.getUserId()))));
   }
 
-  @Override
-  public void iceRestartAudio(UUID meetingId, String sdp, UserPrincipal currentUser) {
-    Meeting meeting = validateMeeting(meetingId);
-    validateMeetingParticipant(currentUser.getId(), meeting);
-    videoServerService.iceRestartAudio(currentUser.getId(), meetingId.toString(), sdp);
-  }
-
-  @Override
-  public void iceRestartVideo(UUID meetingId, String sdp, UserPrincipal currentUser) {
-    Meeting meeting = validateMeeting(meetingId);
-    validateMeetingParticipant(currentUser.getId(), meeting);
-    videoServerService.iceRestartVideo(currentUser.getId(), meetingId.toString(), sdp);
-  }
-
-  @Override
-  public Optional<Participant> getByQueueId(UUID queueId) {
-    return participantRepository.getByQueueId(queueId.toString());
-  }
-
-  @Override
-  public Participant updateParticipantQueueId(UUID userId, UUID meetingId, UUID newQueueId) {
-    Optional<Participant> participant =
-        participantRepository.getById(meetingId.toString(), userId.toString());
-    if (participant.isPresent()) {
-      return participantRepository.update(participant.get().queueId(newQueueId.toString()));
-    } else {
-      throw new NotFoundException(
-          String.format("Participant '%s' not found in meeting '%s'", userId, meetingId));
-    }
-  }
-
   private void removeMeetingParticipant(Participant participant, Meeting meeting, Room room) {
     videoServerService.destroyMeetingParticipant(participant.getUserId(), meeting.getId());
     participantRepository.remove(participant);
+    List<Subscription> subscriptions = room.getSubscriptions();
     eventDispatcher.sendToUserExchange(
-        room.getSubscriptions().stream().map(Subscription::getUserId).toList(),
+        subscriptions.stream().map(Subscription::getUserId).toList(),
         MeetingParticipantLeft.create()
             .meetingId(UUID.fromString(meeting.getId()))
             .userId(UUID.fromString(participant.getUserId()))
@@ -304,6 +275,20 @@ public class ParticipantServiceImpl implements ParticipantService {
           UserPrincipal.create(UUID.fromString(participant.getUserId())),
           UUID.fromString(meeting.getId()));
     }
+    cleanupTemporaryMember(participant, room, subscriptions);
+  }
+
+  private void cleanupTemporaryMember(
+      Participant participant, Room room, List<Subscription> subscriptions) {
+    subscriptions.stream()
+        .filter(s -> s.getUserId().equals(participant.getUserId()))
+        .findFirst()
+        .ifPresent(
+            s -> {
+              if (s.isTemporary()) {
+                membersService.deleteRoomMember(s.getUserId(), room);
+              }
+            });
   }
 
   @Override
@@ -444,15 +429,29 @@ public class ParticipantServiceImpl implements ParticipantService {
     videoServerService.offerRtcAudioStream(currentUser.getId(), meetingId.toString(), sdp);
   }
 
+  @Override
+  public void iceRestartAudio(UUID meetingId, String sdp, UserPrincipal currentUser) {
+    Meeting meeting = validateMeeting(meetingId);
+    validateMeetingParticipant(currentUser.getId(), meeting);
+    videoServerService.iceRestartAudio(currentUser.getId(), meetingId.toString(), sdp);
+  }
+
+  @Override
+  public void iceRestartVideo(UUID meetingId, String sdp, UserPrincipal currentUser) {
+    Meeting meeting = validateMeeting(meetingId);
+    validateMeetingParticipant(currentUser.getId(), meeting);
+    videoServerService.iceRestartVideo(currentUser.getId(), meetingId.toString(), sdp);
+  }
+
   private Participant validateMeetingParticipant(String userId, Meeting meeting) {
     return meeting.getParticipants().stream()
         .filter(p -> userId.equals(p.getUserId()))
         .findAny()
         .orElseThrow(
-            () ->
-                new NotFoundException(
-                    String.format(
-                        "User '%s' not found into meeting '%s'", userId, meeting.getId())));
+            () -> {
+              return new NotFoundException(
+                  String.format("User '%s' not found into meeting '%s'", userId, meeting.getId()));
+            });
   }
 
   @Override
@@ -528,5 +527,22 @@ public class ParticipantServiceImpl implements ParticipantService {
   @Override
   public void clear(UUID meetingId) {
     participantRepository.clear(meetingId.toString());
+  }
+
+  @Override
+  public Optional<Participant> getByQueueId(UUID queueId) {
+    return participantRepository.getByQueueId(queueId.toString());
+  }
+
+  @Override
+  public Participant updateParticipantQueueId(UUID userId, UUID meetingId, UUID newQueueId) {
+    Optional<Participant> participant =
+        participantRepository.getById(meetingId.toString(), userId.toString());
+    if (participant.isPresent()) {
+      return participantRepository.update(participant.get().queueId(newQueueId.toString()));
+    } else {
+      throw new NotFoundException(
+          String.format("Participant '%s' not found in meeting '%s'", userId, meetingId));
+    }
   }
 }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/MembersServiceImplTest.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 @UnitTest
 class MembersServiceImplTest {
@@ -413,10 +414,125 @@ class MembersServiceImplTest {
       verify(messageDispatcher, times(1))
           .sendAffiliationMessage(
               roomId.toString(), user1Id.toString(), user2Id.toString(), MessageType.MEMBER_ADDED);
-      verify(subscriptionRepository, times(1)).insert(any(Subscription.class));
+
+      ArgumentCaptor<Subscription> subscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+      verify(subscriptionRepository, times(1)).insert(subscriptionCaptor.capture());
+      Subscription capturedSubscription = subscriptionCaptor.getValue();
+      assertEquals(user2Id.toString(), capturedSubscription.getUserId());
+      assertFalse(capturedSubscription.isOwner());
+      assertFalse(capturedSubscription.isExternal());
+      assertFalse(capturedSubscription.isTemporary());
+      assertNotNull(capturedSubscription.getJoinedAt());
+
       verify(roomUserSettingsRepository, times(1))
           .getByRoomIdAndUserId(roomId.toString(), user2Id.toString());
       verify(roomUserSettingsRepository, times(1)).save(any(RoomUserSettings.class));
+      verify(eventDispatcher, times(1))
+          .sendToUserExchange(
+              List.of(user1Id.toString(), user3Id.toString(), user2Id.toString()),
+              RoomMemberAdded.create()
+                  .roomId(UUID.fromString(room.getId()))
+                  .userId(user2Id)
+                  .isOwner(false));
+    }
+
+    @Test
+    @DisplayName("Correctly adds a temporary member to a group room")
+    void insertRoomMember_temporaryMember() {
+      Room room = generateRoom(RoomTypeDto.TEMPORARY);
+      room.subscriptions(
+          new ArrayList<>(
+              List.of(
+                  Subscription.create(room, user1Id.toString()).owner(true),
+                  Subscription.create(room, user3Id.toString()).owner(false))));
+      UserPrincipal principal = UserPrincipal.create(user1Id);
+
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
+      when(userService.userExists(user2Id, principal)).thenReturn(true);
+      when(subscriptionRepository.insert(any(Subscription.class)))
+          .thenReturn(Subscription.create(room, user2Id.toString()).temporary(true));
+
+      List<MemberInsertedDto> members =
+          membersService.insertRoomMembers(
+              roomId,
+              List.of(
+                  MemberToInsertDto.create().userId(user2Id).temporary(true).historyCleared(false)),
+              principal);
+      assertEquals(1, members.size());
+      MemberInsertedDto memberInsertedDto = members.get(0);
+      assertNotNull(memberInsertedDto);
+      assertEquals(user2Id, memberInsertedDto.getUserId());
+
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
+      verify(userService, times(1)).userExists(user2Id, principal);
+      verify(messageDispatcher, times(1))
+          .addRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
+      verify(messageDispatcher, times(1))
+          .sendAffiliationMessage(
+              roomId.toString(), user1Id.toString(), user2Id.toString(), MessageType.MEMBER_ADDED);
+
+      ArgumentCaptor<Subscription> subscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+      verify(subscriptionRepository, times(1)).insert(subscriptionCaptor.capture());
+      Subscription capturedSubscription = subscriptionCaptor.getValue();
+      assertEquals(user2Id.toString(), capturedSubscription.getUserId());
+      assertFalse(capturedSubscription.isOwner());
+      assertFalse(capturedSubscription.isExternal());
+      assertTrue(capturedSubscription.isTemporary());
+      assertNotNull(capturedSubscription.getJoinedAt());
+
+      verify(eventDispatcher, times(1))
+          .sendToUserExchange(
+              List.of(user1Id.toString(), user3Id.toString(), user2Id.toString()),
+              RoomMemberAdded.create()
+                  .roomId(UUID.fromString(room.getId()))
+                  .userId(user2Id)
+                  .isOwner(false));
+    }
+
+    @Test
+    @DisplayName("Correctly adds an external member to a group room")
+    void insertRoomMember_externalMember() {
+      Room room = generateRoom(RoomTypeDto.TEMPORARY);
+      room.subscriptions(
+          new ArrayList<>(
+              List.of(
+                  Subscription.create(room, user1Id.toString()).owner(true),
+                  Subscription.create(room, user3Id.toString()).owner(false))));
+      UserPrincipal principal = UserPrincipal.create(user1Id);
+
+      when(roomService.getRoomAndValidateUser(roomId, principal, true)).thenReturn(room);
+      when(userService.userExists(user2Id, principal)).thenReturn(true);
+      when(subscriptionRepository.insert(any(Subscription.class)))
+          .thenReturn(Subscription.create(room, user2Id.toString()).external(true));
+
+      List<MemberInsertedDto> members =
+          membersService.insertRoomMembers(
+              roomId,
+              List.of(
+                  MemberToInsertDto.create().userId(user2Id).external(true).historyCleared(false)),
+              principal);
+      assertEquals(1, members.size());
+      MemberInsertedDto memberInsertedDto = members.get(0);
+      assertNotNull(memberInsertedDto);
+      assertEquals(user2Id, memberInsertedDto.getUserId());
+
+      verify(roomService, times(1)).getRoomAndValidateUser(roomId, principal, true);
+      verify(userService, times(1)).userExists(user2Id, principal);
+      verify(messageDispatcher, times(1))
+          .addRoomMember(roomId.toString(), user1Id.toString(), user2Id.toString());
+      verify(messageDispatcher, times(1))
+          .sendAffiliationMessage(
+              roomId.toString(), user1Id.toString(), user2Id.toString(), MessageType.MEMBER_ADDED);
+
+      ArgumentCaptor<Subscription> subscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+      verify(subscriptionRepository, times(1)).insert(subscriptionCaptor.capture());
+      Subscription capturedSubscription = subscriptionCaptor.getValue();
+      assertEquals(user2Id.toString(), capturedSubscription.getUserId());
+      assertFalse(capturedSubscription.isOwner());
+      assertTrue(capturedSubscription.isExternal());
+      assertFalse(capturedSubscription.isTemporary());
+      assertNotNull(capturedSubscription.getJoinedAt());
+
       verify(eventDispatcher, times(1))
           .sendToUserExchange(
               List.of(user1Id.toString(), user3Id.toString(), user2Id.toString()),

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImplTest.java
@@ -35,9 +35,7 @@ import com.zextras.carbonio.chats.core.exception.NotFoundException;
 import com.zextras.carbonio.chats.core.infrastructure.event.EventDispatcher;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.VideoServerService;
 import com.zextras.carbonio.chats.core.repository.ParticipantRepository;
-import com.zextras.carbonio.chats.core.service.MeetingService;
-import com.zextras.carbonio.chats.core.service.ParticipantService;
-import com.zextras.carbonio.chats.core.service.RoomService;
+import com.zextras.carbonio.chats.core.service.*;
 import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
 import com.zextras.carbonio.chats.model.AudioStreamSettingsDto;
 import com.zextras.carbonio.chats.model.HandStatusDto;
@@ -64,6 +62,7 @@ class ParticipantServiceImplTest {
   private final ParticipantService participantService;
   private final MeetingService meetingService;
   private final RoomService roomService;
+  private final MembersService membersService;
   private final ParticipantRepository participantRepository;
   private final VideoServerService videoServerService;
   private final EventDispatcher eventDispatcher;
@@ -72,6 +71,7 @@ class ParticipantServiceImplTest {
   public ParticipantServiceImplTest() {
     this.meetingService = mock(MeetingService.class);
     this.roomService = mock(RoomService.class);
+    this.membersService = mock(MembersService.class);
     this.participantRepository = mock(ParticipantRepository.class);
     this.videoServerService = mock(VideoServerService.class);
     this.eventDispatcher = mock(EventDispatcher.class);
@@ -80,6 +80,7 @@ class ParticipantServiceImplTest {
         new ParticipantServiceImpl(
             meetingService,
             roomService,
+            membersService,
             participantRepository,
             videoServerService,
             eventDispatcher,
@@ -464,7 +465,12 @@ class ParticipantServiceImplTest {
               List.of(user1Id.toString(), user2Id.toString(), user3Id.toString()),
               MeetingParticipantLeft.create().meetingId(permanentMeetingId).userId(user4Id));
       verifyNoMoreInteractions(
-          meetingService, roomService, participantRepository, videoServerService, eventDispatcher);
+          meetingService,
+          roomService,
+          membersService,
+          participantRepository,
+          videoServerService,
+          eventDispatcher);
     }
 
     @Test
@@ -491,7 +497,12 @@ class ParticipantServiceImplTest {
               MeetingParticipantLeft.create().meetingId(meeting2Id).userId(user2Id));
       verify(meetingService, times(1)).stopMeeting(UserPrincipal.create(user2Id), meeting2Id);
       verifyNoMoreInteractions(
-          meetingService, roomService, participantRepository, videoServerService, eventDispatcher);
+          meetingService,
+          roomService,
+          membersService,
+          participantRepository,
+          videoServerService,
+          eventDispatcher);
     }
 
     @Test
@@ -523,13 +534,18 @@ class ParticipantServiceImplTest {
               List.of(user1Id.toString(), user4Id.toString()),
               MeetingParticipantLeft.create().meetingId(scheduledMeetingId).userId(user1Id));
       verifyNoMoreInteractions(
-          meetingService, roomService, participantRepository, videoServerService, eventDispatcher);
+          meetingService,
+          roomService,
+          membersService,
+          participantRepository,
+          videoServerService,
+          eventDispatcher);
     }
 
     @Test
     @DisplayName(
-        "It removes the current non-owner user as meeting participant from a temporary room")
-    void removeMeetingParticipant_testOkRoomTemporaryAndUserIsNotOwner() {
+        "It removes the current external user as meeting participant from a temporary room")
+    void removeMeetingParticipant_testOkRoomTemporaryAndUserIsExternal() {
       UserPrincipal currentUser = UserPrincipal.create(user4Id).queueId(user4Queue1);
       scheduledMeeting.participants(List.of(participant1Session1, participant4Session1));
       when(meetingService.getMeetingEntity(scheduledMeetingId))
@@ -541,7 +557,7 @@ class ParticipantServiceImplTest {
       when(roomService.getRoomAndValidateUser(scheduledRoomId, currentUser, false))
           .thenReturn(scheduledRoom);
       when(participantRepository.getByMeetingId(scheduledMeetingId.toString()))
-          .thenReturn(List.of(participant4Session1));
+          .thenReturn(List.of(participant1Session1));
 
       participantService.removeMeetingParticipant(scheduledMeetingId, currentUser);
 
@@ -556,7 +572,51 @@ class ParticipantServiceImplTest {
               List.of(user1Id.toString(), user4Id.toString()),
               MeetingParticipantLeft.create().meetingId(scheduledMeetingId).userId(user4Id));
       verifyNoMoreInteractions(
-          meetingService, roomService, participantRepository, videoServerService, eventDispatcher);
+          meetingService,
+          roomService,
+          membersService,
+          participantRepository,
+          videoServerService,
+          eventDispatcher);
+    }
+
+    @Test
+    @DisplayName(
+        "It removes the current temporary user as meeting participant from a temporary room")
+    void removeMeetingParticipant_testOkRoomTemporaryAndUserIsTemporary() {
+      UserPrincipal currentUser = UserPrincipal.create(user4Id).queueId(user4Queue1);
+      scheduledMeeting.participants(List.of(participant1Session1, participant4Session1));
+      when(meetingService.getMeetingEntity(scheduledMeetingId))
+          .thenReturn(Optional.of(scheduledMeeting));
+      scheduledRoom.subscriptions(
+          List.of(
+              Subscription.create(scheduledRoom, user1Id.toString()).owner(true),
+              Subscription.create(scheduledRoom, user4Id.toString()).temporary(true)));
+      when(roomService.getRoomAndValidateUser(scheduledRoomId, currentUser, false))
+          .thenReturn(scheduledRoom);
+      when(participantRepository.getByMeetingId(scheduledMeetingId.toString()))
+          .thenReturn(List.of(participant1Session1));
+
+      participantService.removeMeetingParticipant(scheduledMeetingId, currentUser);
+
+      verify(meetingService, times(1)).getMeetingEntity(scheduledMeetingId);
+      verify(roomService, times(1)).getRoomAndValidateUser(scheduledRoomId, currentUser, false);
+      verify(participantRepository, times(1)).remove(participant4Session1);
+      verify(participantRepository, times(1)).getByMeetingId(scheduledMeetingId.toString());
+      verify(videoServerService, times(1))
+          .destroyMeetingParticipant(user4Id.toString(), scheduledMeetingId.toString());
+      verify(eventDispatcher, times(1))
+          .sendToUserExchange(
+              List.of(user1Id.toString(), user4Id.toString()),
+              MeetingParticipantLeft.create().meetingId(scheduledMeetingId).userId(user4Id));
+      verify(membersService, times(1)).deleteRoomMember(user4Id.toString(), scheduledRoom);
+      verifyNoMoreInteractions(
+          meetingService,
+          roomService,
+          membersService,
+          participantRepository,
+          videoServerService,
+          eventDispatcher);
     }
 
     @Test
@@ -570,7 +630,7 @@ class ParticipantServiceImplTest {
 
       verify(meetingService, times(1)).getMeetingEntity(permanentMeetingId);
       verify(roomService, times(1)).getRoomAndValidateUser(roomId, currentUser, false);
-      verifyNoMoreInteractions(meetingService, roomService);
+      verifyNoMoreInteractions(meetingService, roomService, membersService);
       verifyNoInteractions(participantRepository, videoServerService, eventDispatcher);
     }
   }

--- a/carbonio-ws-collaboration-openapi/src/main/resources/api.yaml
+++ b/carbonio-ws-collaboration-openapi/src/main/resources/api.yaml
@@ -6,8 +6,8 @@ openapi: 3.0.3
 info:
   title: Zextras Carbonio Workstream Collaboration API
   description: Zextras Carbonio Workstream Collaboration HTTP APIs definition.
-  version: 1.6.8
-  x-supported-versions: [ "1.6.8", "1.6.7", "1.6.6", "1.6.5", "1.6.4", "1.6.3", "1.6.2", "1.6.1", "1.6.0" ]
+  version: 1.6.9
+  x-supported-versions: [ "1.6.9", "1.6.8", "1.6.7", "1.6.6", "1.6.5", "1.6.4", "1.6.3", "1.6.2", "1.6.1", "1.6.0" ]
 
 servers:
   - url: http://localhost:10000
@@ -380,7 +380,7 @@ paths:
       tags:
         - Rooms
         - Attachments
-      summary: Retrieves paged list of metadata of every attachment uploaded to the room  and the filter for the next page
+      summary: Retrieves paged list of metadata of every attachment uploaded to the room and the filter for the next page
       operationId: listRoomAttachmentsInfo
       parameters:
         - $ref: '#/components/parameters/pathRoomId'
@@ -1714,6 +1714,14 @@ components:
           type: boolean
           default: false
           description: indicates whether it is the owner
+        external:
+          type: boolean
+          default: false
+          description: indicates whether it is an external user
+        temporary:
+          type: boolean
+          default: false
+          description: indicates whether it is a temporary user
       required: [ userId ]
     MembersToInsert:
       type: array


### PR DESCRIPTION
feat: set internal users as temporary users when joining temporary room through waiting room

ref: CO-2390