### PR TITLE
ci(jenkins): migrate Maven stages to mavenStage()

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,16 +48,6 @@ pipeline {
             defaultValue: false,
             description: 'Check this to prepare a new release (creates pre-release branch and PR)'
         )
-        booleanParam(
-            name: 'SKIP_TESTS',
-            defaultValue: false,
-            description: 'Skip unit tests and integration tests'
-        )
-        booleanParam(
-            name: 'SKIP_CHECKS',
-            defaultValue: false,
-            description: 'Skip coverage and SonarQube analysis'
-        )
     }
 
     stages {
@@ -70,54 +60,14 @@ pipeline {
             }
         }
 
-        stage('Build jar') {
+        stage('Maven') {
             steps {
                 script {
-                    def profile = '-P dev'
-                    if (env.TAG_NAME) {
-                        profile = '-P prod'
-                    }
-                    container('jdk-21') {
-                        sh """
-                            mvn ${MVN_OPTS} clean package ${profile}
-                            cp carbonio-ws-collaboration-boot/target/carbonio-ws-collaboration-ce-*-fatjar.jar package/carbonio-ws-collaboration-ce.jar
-                        """
-                    }
-                }
-            }
-        }
-
-        stage('Tests') {
-            when {
-                expression { params.SKIP_TESTS == false }
-            }
-            steps {
-                container('jdk-21') {
-                    sh """
-                        mvn ${MVN_OPTS} \
-                        -Dlogback.configurationFile="\$(pwd)"/carbonio-ws-collaboration-boot/src/main/resources/logback-test-silent.xml \
-                        verify
-                    """
-                    recordCoverage(tools: [[pattern: 'target/site/jacoco-all-tests/jacoco.xml']])
-                }
-            }
-        }
-
-        stage('SonarQube analysis') {
-            when {
-                allOf {
-                    expression { params.SKIP_CHECKS == false }
-                    anyOf {
-                        branch 'devel'
-                        expression { env.BRANCH_NAME.contains("PR") }
-                    }
-                }
-            }
-            steps {
-                container('jdk-21') {
-                    withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
-                        sh "mvn ${MVN_OPTS} org.sonarsource.scanner.maven:sonar-maven-plugin:sonar"
-                    }
+                    mavenStage(
+                        postBuildScript: 'cp carbonio-ws-collaboration-boot/target/carbonio-ws-collaboration-ce-*-fatjar.jar package/carbonio-ws-collaboration-ce.jar',
+                        extraTestArgs: '-Dlogback.configurationFile="$(pwd)"/carbonio-ws-collaboration-boot/src/main/resources/logback-test-silent.xml',
+                        overrideCoverageCmd: 'true',
+                    )
                 }
             }
         }


### PR DESCRIPTION
## What

Replace hand-rolled `Build jar`, `Tests`, and `SonarQube analysis` stages with a single `mavenStage()` call from `jenkins-lib-common@1.5.0`.

## Why

Reduces 60 lines of boilerplate to 5. Delegates profile auto-detection, `withCredentials`, `junit` recording, JaCoCo detection, SonarQube gating, and deploy gating to the shared library.

## Changes

- Remove `SKIP_TESTS` and `SKIP_CHECKS` parameters (escape hatches superseded by `mavenStage`)
- Remove explicit `container('jdk-21')`, `withSonarQubeEnv`, `recordCoverage` calls
- Move `cp ...fatjar.jar` to `postBuildScript`
- Pass `-Dlogback.configurationFile=...` via `extraTestArgs`
- Use `overrideCoverageCmd: 'true'` because the POM lacks a `generate-jacoco-full-report` profile; JaCoCo runs during `mvn verify` in the test stage and the parser auto-scans for the resulting `jacoco.xml`

## Behavior delta

| Behavior | Before | After |
|---|---|---|
| Profile (devel) | `-P dev` | `-P dev` (auto-detect) ✅ |
| Profile (tag) | `-P prod` | `-P prod` (auto-detect) ✅ |
| Skip tests | `SKIP_TESTS` param | not possible (removed) |
| Skip Sonar | `SKIP_CHECKS` param | not possible (removed) |
| `junit` UI | absent | added ✅ |
| Coverage | `recordCoverage` with explicit path | `recordCoverage` with JACOCO parser auto-scan |
| Deploy | none | none (no `deployArtifacts: true`) |