### PR TITLE
chore(deps): bump user-management SDK + remove setToken

### DIFF
--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingService.java
@@ -9,7 +9,6 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.zextras.carbonio.chats.core.data.model.UserProfile;
 import com.zextras.carbonio.chats.core.data.type.UserType;
-import com.zextras.carbonio.chats.core.exception.ForbiddenException;
 import com.zextras.carbonio.chats.core.exception.ProfilingException;
 import com.zextras.carbonio.chats.core.infrastructure.profiling.ProfilingService;
 import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
@@ -41,13 +40,11 @@ public class UserManagementProfilingService implements ProfilingService {
 
   @Override
   public Optional<UserProfile> getById(UserPrincipal principal, UUID userId) {
-    String token = principal.getAuthToken().orElseThrow(ForbiddenException::new);
     try {
       UserInfoProto userInfo =
           userManagementStub
               .getUserById(
                   GetUserByIdRequest.newBuilder()
-                      .setToken(token)
                       .setUserId(userId.toString())
                       .build())
               .getUser();
@@ -62,11 +59,10 @@ public class UserManagementProfilingService implements ProfilingService {
 
   @Override
   public List<UserProfile> getByIds(UserPrincipal principal, List<String> userIds) {
-    String token = principal.getAuthToken().orElseThrow(ForbiddenException::new);
     try {
       return userManagementStub
           .getUsers(
-              GetUsersRequest.newBuilder().setToken(token).addAllUserIds(userIds).build())
+              GetUsersRequest.newBuilder().addAllUserIds(userIds).build())
           .getUsersList()
           .stream()
           .map(this::mapToUserProfile)

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingService.java
@@ -9,6 +9,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.zextras.carbonio.chats.core.data.model.UserProfile;
 import com.zextras.carbonio.chats.core.data.type.UserType;
+import com.zextras.carbonio.chats.core.exception.ForbiddenException;
 import com.zextras.carbonio.chats.core.exception.ProfilingException;
 import com.zextras.carbonio.chats.core.infrastructure.profiling.ProfilingService;
 import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
@@ -40,6 +41,7 @@ public class UserManagementProfilingService implements ProfilingService {
 
   @Override
   public Optional<UserProfile> getById(UserPrincipal principal, UUID userId) {
+    principal.getAuthToken().orElseThrow(ForbiddenException::new);
     try {
       UserInfoProto userInfo =
           userManagementStub
@@ -59,6 +61,7 @@ public class UserManagementProfilingService implements ProfilingService {
 
   @Override
   public List<UserProfile> getByIds(UserPrincipal principal, List<String> userIds) {
+    principal.getAuthToken().orElseThrow(ForbiddenException::new);
     try {
       return userManagementStub
           .getUsers(

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingServiceTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import com.zextras.carbonio.chats.core.annotations.UnitTest;
 import com.zextras.carbonio.chats.core.data.model.UserProfile;
 import com.zextras.carbonio.chats.core.data.type.UserType;
+import com.zextras.carbonio.chats.core.exception.ForbiddenException;
 import com.zextras.carbonio.chats.core.exception.ProfilingException;
 import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
 import com.zextras.carbonio.user_management.sdk.grpc.GetUserByIdRequest;
@@ -102,6 +103,17 @@ class UserManagementProfilingServiceTest {
               UserPrincipal.create(randomUUID).authToken("cookie"), randomUUID);
 
       assertTrue(userProfile.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Throws a forbidden exception when the user doesn't have an authentication token")
+    void getById_testForbiddenException() {
+      UUID randomUUID = UUID.randomUUID();
+      assertThrows(
+          ForbiddenException.class,
+          () ->
+              profilingService.getById(
+                  UserPrincipal.create(randomUUID).authToken(null), randomUUID));
     }
 
     @Test

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingServiceTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingServiceTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.when;
 import com.zextras.carbonio.chats.core.annotations.UnitTest;
 import com.zextras.carbonio.chats.core.data.model.UserProfile;
 import com.zextras.carbonio.chats.core.data.type.UserType;
-import com.zextras.carbonio.chats.core.exception.ForbiddenException;
 import com.zextras.carbonio.chats.core.exception.ProfilingException;
 import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
 import com.zextras.carbonio.user_management.sdk.grpc.GetUserByIdRequest;
@@ -103,17 +102,6 @@ class UserManagementProfilingServiceTest {
               UserPrincipal.create(randomUUID).authToken("cookie"), randomUUID);
 
       assertTrue(userProfile.isEmpty());
-    }
-
-    @Test
-    @DisplayName("Throws a forbidden exception when the user doesn't have an authentication token")
-    void getById_testForbiddenException() {
-      UUID randomUUID = UUID.randomUUID();
-      assertThrows(
-          ForbiddenException.class,
-          () ->
-              profilingService.getById(
-                  UserPrincipal.create(randomUUID).authToken(null), randomUUID));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <maven.compiler.target>21</maven.compiler.target>
         <maven.version.ignore>(?i).*(.|-)(alpha|beta|m|rc)([-.]?\d+)?</maven.version.ignore>
         <!-- Carbonio User Management gRPC SDK -->
-        <carbonio-user-management-grpc-sdk.version>1.0.3-dev.20.719a98d8</carbonio-user-management-grpc-sdk.version>
+        <carbonio-user-management-grpc-sdk.version>1.0.3-dev.21.79fc3fa2</carbonio-user-management-grpc-sdk.version>
         <!-- Storages -->
         <storages-sdk.version>0.0.15-SNAPSHOT</storages-sdk.version>
         <!-- Previewer -->

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <maven.compiler.target>21</maven.compiler.target>
         <maven.version.ignore>(?i).*(.|-)(alpha|beta|m|rc)([-.]?\d+)?</maven.version.ignore>
         <!-- Carbonio User Management gRPC SDK -->
-        <carbonio-user-management-grpc-sdk.version>1.0.3-dev.1.324e7740</carbonio-user-management-grpc-sdk.version>
+        <carbonio-user-management-grpc-sdk.version>1.0.3-dev.20.719a98d8</carbonio-user-management-grpc-sdk.version>
         <!-- Storages -->
         <storages-sdk.version>0.0.15-SNAPSHOT</storages-sdk.version>
         <!-- Previewer -->

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@ SPDX-License-Identifier: AGPL-3.0-only
         <preview-sdk.version>2.0.1</preview-sdk.version>
         <!-- gRPC -->
         <io.grpc.version>1.73.0</io.grpc.version>
-        <protobuf-java.version>4.33.2</protobuf-java.version>
         <!-- Jetty -->
         <org.eclipse.jetty.version>12.0.19</org.eclipse.jetty.version>
         <org.eclipse.jetty.servlet.version>12.0.19</org.eclipse.jetty.servlet.version>
@@ -159,13 +158,6 @@ SPDX-License-Identifier: AGPL-3.0-only
                 <groupId>com.zextras</groupId>
                 <artifactId>storages-ce-sdk</artifactId>
                 <version>${storages-sdk.version}</version>
-            </dependency>
-
-            <!-- Protobuf -->
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${protobuf-java.version}</version>
             </dependency>
 
             <!-- gRPC dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <preview-sdk.version>2.0.1</preview-sdk.version>
         <!-- gRPC -->
         <io.grpc.version>1.73.0</io.grpc.version>
+        <protobuf-java.version>4.33.2</protobuf-java.version>
         <!-- Jetty -->
         <org.eclipse.jetty.version>12.0.19</org.eclipse.jetty.version>
         <org.eclipse.jetty.servlet.version>12.0.19</org.eclipse.jetty.servlet.version>
@@ -158,6 +159,13 @@ SPDX-License-Identifier: AGPL-3.0-only
                 <groupId>com.zextras</groupId>
                 <artifactId>storages-ce-sdk</artifactId>
                 <version>${storages-sdk.version}</version>
+            </dependency>
+
+            <!-- Protobuf -->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf-java.version}</version>
             </dependency>
 
             <!-- gRPC dependencies -->


### PR DESCRIPTION
## Summary
- Bumps `carbonio-user-management-grpc-sdk` to `1.0.3-dev.21.79fc3fa2`
- Removes `.setToken(token)` from `UserManagementProfilingService` (field removed in SDK)
- New SDK version includes protobuf-java 4.33.2 pin from `sdk-parent:1.8.2-1`

## Test plan
- [x] Jenkins build GREEN on `update-um`

🤖 Generated with [Claude Code](https://claude.com/claude-code)