### PR TITLE
chore(ci): bump jenkins-lib-common to 1.7.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ library(
 )
 
 library(
-    identifier: 'jenkins-lib-common@1.7.1',
+    identifier: 'jenkins-lib-common@1.7.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
## Summary

- Bumps `jenkins-lib-common` from `1.7.1` to `1.7.2`