### PR TITLE
chore(deps): update jenkins-lib-common to v2.8.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ library(
 )
 
 library(
-    identifier: 'jenkins-lib-common@v2.8.6',
+    identifier: 'jenkins-lib-common@v2.8.7',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ library(
 )
 
 library(
-    identifier: 'jenkins-lib-common@1.7.5',
+    identifier: 'jenkins-lib-common@v2.8.6',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,9 +90,7 @@ pipeline {
                 jfrog 'jfrog-cli'
             }
             steps {
-                uploadStage(
-                    packages: yapHelper.resolvePackageNames()
-                )
+                uploadStage()
             }
         }
 


### PR DESCRIPTION
## Description

Upgrade `jenkins-lib-common` from `1.7.5` to `v2.8.7`.

### Changes applied

- Updated library version reference to `v2.8.7`
- Migrated `uploadStage(packages: ...)` to the new API
  (packages parameter was removed in v2.8.0 — the library now resolves
  package metadata internally from PKGBUILD files)

### Breaking changes in this upgrade

| Version | Change | Action Taken |
|---------|--------|--------------|
| v2.0.0 | Trunk-based branch guards replace `devel*`/`release*` | N/A — `when { branch 'devel' }` guards retained (they guard `prepareRelease()`/`tagRelease()`, not upload/deploy) |
| v2.8.0 | `uploadStage(packages:)` removed, hard-errors at runtime | Removed `packages:` arg; orphaned `yapHelper.resolvePackageNames()` call removed |

### Verification

- [x] Jenkinsfile syntax is valid
- [x] No `packages:` arg in `uploadStage()` calls
- [x] No orphaned `yapHelper.getPackageNames()` calls
- [ ] PR build passes

## Type of change

- [x] Chore / CI (`chore:` / `ci:` / `test:` → no release)

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Branch is rebased on latest default branch with a linear history

## Notes for reviewers

Automated lib-common upgrade built on top of the Renovate bot PR. Two migration commits added on top of Renovate's version bump:
1. Version bump from `v2.8.6` → `v2.8.7`
2. Migration of `uploadStage(packages:)` to the new zero-argument API (v2.8.0+ breaking change)

Please verify the Upload stage runs correctly on the PR build.