### PR TITLE
fix(deps): add explicit service-discover-base dependency

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -13,6 +13,7 @@ depends=(
   "jq"
   "pending-setups"
   "service-discover"
+  "service-discover-base"
 )
 backup=(
   "etc/carbonio/ws-collaboration/logback.xml"


### PR DESCRIPTION
## Summary

Fixes CO-3711: sidecar services fail when `/usr/bin/service-discover-wrapper.sh` is missing.

## Root Cause

`service-discover-wrapper.sh` is provided by `service-discover-base`. This package was only a transitive dependency, so if it became stale or mismatched (e.g. installed from a devel repo with a NEVRA no longer available), `dnf reinstall` could not restore the missing file.

## Fix

Add `service-discover-base` as an explicit dependency so the package manager enforces it at install/upgrade time.

## References

- [CO-3711](https://zextras.atlassian.net/browse/CO-3711)

[CO-3711]: https://zextras.atlassian.net/browse/CO-3711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ