### PR TITLE
feat: add iceRestartScreen endpoint for WebRTC ICE restart in meetings

### DIFF
--- a/API_VERSIONING.md
+++ b/API_VERSIONING.md
@@ -4,6 +4,16 @@ This document tracks internal changes related to API versioning, both for the RE
 
 ---
 
+## Version 1.6.13
+
+### Changes (1.6.13)
+
+- **API**: Added PUT `/meetings/${meetingId}/screen/iceRestart` endpoint — triggers WebRTC
+  ICE restart for the current user's screen-share (publisher) stream. Mirrors the existing
+  video ICE restart; the inbound side is already covered by the video ICE restart endpoint.
+
+---
+
 ## Version 1.6.12
 
 ### Changes (1.6.12)

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/VideoServerService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/VideoServerService.java
@@ -42,4 +42,6 @@ public interface VideoServerService extends HealthIndicator {
   void iceRestartAudio(String userId, String meetingId, String sdp);
 
   void iceRestartVideo(String userId, String meetingId, String sdp);
+
+  void iceRestartScreen(String userId, String meetingId, String sdp);
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/impl/VideoServerServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/videoserver/impl/VideoServerServiceImpl.java
@@ -886,6 +886,32 @@ public class VideoServerServiceImpl implements VideoServerService {
     }
   }
 
+  @Override
+  public void iceRestartScreen(String userId, String meetingId, String sdp) {
+    VideoServerMeeting videoServerMeeting = getVideoServerMeeting(meetingId);
+    VideoServerSession videoServerSession = getVideoServerSession(userId, videoServerMeeting);
+
+    iceRestartScreenWithSdp(
+        videoServerSession.getConnectionId(), videoServerSession.getScreenHandleId(), sdp);
+  }
+
+  private void iceRestartScreenWithSdp(String connectionId, String screenHandleId, String sdp) {
+
+    VideoRoomResponse videoRoomResponse =
+        sendVideoRoomPluginMessage(
+            connectionId,
+            screenHandleId,
+            VideoRoomConfigureRequest.create().request(VideoRoomConfigureRequest.CONFIGURE),
+            RtcSessionDescription.create().type(RtcType.OFFER).sdp(sdp));
+
+    if (!VideoRoomResponse.ACK.equals(videoRoomResponse.getStatus())) {
+      throw new VideoServerException(
+          "An error occurred while user with connection id "
+              + connectionId
+              + " is triggering screen ice restart");
+    }
+  }
+
   private VideoServerMeeting getVideoServerMeeting(String meetingId) {
     return videoServerMeetingRepository
         .getById(meetingId)

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/ParticipantService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/ParticipantService.java
@@ -45,6 +45,8 @@ public interface ParticipantService {
 
   void iceRestartVideo(UUID meetingId, String sdp, UserPrincipal currentUser);
 
+  void iceRestartScreen(UUID meetingId, String sdp, UserPrincipal currentUser);
+
   void updateHandStatus(UUID meetingId, HandStatusDto handStatusDto, UserPrincipal currentUser);
 
   void clear(UUID meetingId);

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImpl.java
@@ -443,6 +443,13 @@ public class ParticipantServiceImpl implements ParticipantService {
     videoServerService.iceRestartVideo(currentUser.getId(), meetingId.toString(), sdp);
   }
 
+  @Override
+  public void iceRestartScreen(UUID meetingId, String sdp, UserPrincipal currentUser) {
+    Meeting meeting = validateMeeting(meetingId);
+    validateMeetingParticipant(currentUser.getId(), meeting);
+    videoServerService.iceRestartScreen(currentUser.getId(), meetingId.toString(), sdp);
+  }
+
   private Participant validateMeetingParticipant(String userId, Meeting meeting) {
     return meeting.getParticipants().stream()
         .filter(p -> userId.equals(p.getUserId()))

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/api/MeetingsApiServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/api/MeetingsApiServiceImpl.java
@@ -370,6 +370,17 @@ public class MeetingsApiServiceImpl implements MeetingsApiService {
   }
 
   @Override
+  public Response iceRestartScreen(
+      UUID meetingId,
+      SessionDescriptionProtocolDto sessionDescriptionProtocolDto,
+      SecurityContext securityContext) {
+    UserPrincipal currentUser = getCurrentUser(securityContext);
+    participantService.iceRestartScreen(
+        meetingId, sessionDescriptionProtocolDto.getSdp(), currentUser);
+    return Response.status(Status.NO_CONTENT).build();
+  }
+
+  @Override
   public Response updateHandStatus(
       UUID meetingId, HandStatusDto handStatusDto, SecurityContext securityContext) {
     UserPrincipal currentUser = getCurrentUser(securityContext);

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/ParticipantServiceImplTest.java
@@ -1968,6 +1968,87 @@ class ParticipantServiceImplTest {
   }
 
   @Nested
+  @DisplayName("Ice restart screen tests")
+  class IceRestartScreenTests {
+
+    @Test
+    @DisplayName("It triggers ice restart for the screen stream for the current user")
+    void iceRestartScreen_testOk() {
+      when(meetingService.getMeetingEntity(permanentMeetingId))
+          .thenReturn(Optional.of(permanentMeeting));
+
+      permanentMeeting.participants(
+          List.of(participant1Session1, participant2Session1, participant4Session1));
+
+      participantService.iceRestartScreen(
+          permanentMeetingId, "sdp", UserPrincipal.create(user1Id).queueId(user1Queue1));
+
+      verify(meetingService, times(1)).getMeetingEntity(permanentMeetingId);
+      verify(videoServerService, times(1))
+          .iceRestartScreen(user1Id.toString(), permanentMeetingId.toString(), "sdp");
+      verifyNoMoreInteractions(meetingService, videoServerService);
+      verifyNoInteractions(roomService, participantRepository, eventDispatcher);
+    }
+
+    @Test
+    @DisplayName("If the requested meeting doesn't exist, it throws a 'not found' exception")
+    void iceRestartScreen_testErrorMeetingNotExists() {
+      when(meetingService.getMeetingEntity(permanentMeetingId)).thenReturn(Optional.empty());
+
+      ChatsHttpException exception =
+          assertThrows(
+              NotFoundException.class,
+              () ->
+                  participantService.iceRestartScreen(
+                      permanentMeetingId,
+                      "sdp",
+                      UserPrincipal.create(user1Id).queueId(user1Queue1)));
+
+      assertEquals(Status.NOT_FOUND.getStatusCode(), exception.getHttpStatusCode());
+      assertEquals(Status.NOT_FOUND.getReasonPhrase(), exception.getHttpStatusPhrase());
+      assertEquals(
+          String.format("Not Found - Meeting '%s' not found", permanentMeetingId),
+          exception.getMessage());
+
+      verify(meetingService, times(1)).getMeetingEntity(permanentMeetingId);
+      verifyNoMoreInteractions(meetingService);
+      verifyNoInteractions(roomService, videoServerService, participantRepository, eventDispatcher);
+    }
+
+    @Test
+    @DisplayName("If the requester is not a meeting participant, it throws a 'not found' exception")
+    void iceRestartScreen_testErrorUserIsNotMeetingParticipant() {
+      when(meetingService.getMeetingEntity(permanentMeetingId))
+          .thenReturn(Optional.of(permanentMeeting));
+
+      ChatsHttpException exception =
+          assertThrows(
+              NotFoundException.class,
+              () ->
+                  participantService.iceRestartScreen(
+                      permanentMeetingId,
+                      "sdp",
+                      UserPrincipal.create(user3Id).queueId(user3Queue1)));
+
+      assertEquals(Status.NOT_FOUND.getStatusCode(), exception.getHttpStatusCode());
+      assertEquals(Status.NOT_FOUND.getReasonPhrase(), exception.getHttpStatusPhrase());
+      assertEquals(
+          String.format(
+              "Not Found - User '%s' not found into meeting '%s'", user3Id, permanentMeetingId),
+          exception.getMessage());
+
+      verify(meetingService, times(1)).getMeetingEntity(permanentMeetingId);
+      verifyNoMoreInteractions(meetingService);
+      verifyNoInteractions(
+          roomService,
+          videoServerService,
+          participantRepository,
+          eventDispatcher,
+          videoServerService);
+    }
+  }
+
+  @Nested
   @DisplayName("Get meeting participants tests")
   class GetMeetingParticipantsTests {
 

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/VideoServerServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/VideoServerServiceImplTest.java
@@ -2869,6 +2869,130 @@ class VideoServerServiceImplTest {
   }
 
   @Nested
+  @DisplayName("Ice restart screen tests")
+  class IceRestartScreenTests {
+
+    @Test
+    @DisplayName("It triggers ice restart for screen")
+    void iceRestartScreen_testOk() {
+      VideoServerMeeting videoServerMeeting = createVideoServerMeeting(meeting1Id);
+      VideoServerSession videoServerSession =
+          VideoServerSession.create()
+              .userId(user1Id.toString())
+              .queueId(queue1Id.toString())
+              .videoServerMeeting(videoServerMeeting)
+              .connectionId(user1SessionId.toString())
+              .screenHandleId(user1ScreenHandleId.toString());
+      videoServerMeeting.videoServerSessions(List.of(videoServerSession));
+
+      VideoRoomResponse iceRestartScreenResponse =
+          VideoRoomResponse.create()
+              .status("ack")
+              .connectionId(user1SessionId.toString())
+              .transactionId("transaction-id")
+              .handleId(user1ScreenHandleId.toString());
+      when(videoServerClient.sendVideoRoomRequest(
+              eq(user1SessionId.toString()),
+              eq(user1ScreenHandleId.toString()),
+              any(VideoServerMessageRequest.class)))
+          .thenReturn(iceRestartScreenResponse);
+
+      videoServerService.iceRestartScreen(
+          user1Id.toString(), meeting1Id.toString(), "session-description-protocol");
+
+      ArgumentCaptor<VideoServerMessageRequest> iceRestartScreenRequestCaptor =
+          ArgumentCaptor.forClass(VideoServerMessageRequest.class);
+
+      verify(videoServerMeetingRepository, times(1)).getById(meeting1Id.toString());
+      verify(videoServerClient, times(1))
+          .sendVideoRoomRequest(
+              eq(user1SessionId.toString()),
+              eq(user1ScreenHandleId.toString()),
+              iceRestartScreenRequestCaptor.capture());
+
+      assertEquals(1, iceRestartScreenRequestCaptor.getAllValues().size());
+      VideoServerMessageRequest iceRestartScreenRequest = iceRestartScreenRequestCaptor.getValue();
+      assertEquals("message", iceRestartScreenRequest.getMessageRequest());
+      assertEquals("token", iceRestartScreenRequest.getApiSecret());
+      assertEquals(
+          "session-description-protocol",
+          iceRestartScreenRequest.getRtcSessionDescription().getSdp());
+      VideoRoomConfigureRequest videoRoomConfigureRequest =
+          (VideoRoomConfigureRequest) iceRestartScreenRequest.getVideoServerPluginRequest();
+      assertEquals("configure", videoRoomConfigureRequest.getRequest());
+    }
+
+    @Test
+    @DisplayName("Try to trigger ice restart for screen stream on a meeting that does not exist")
+    void iceRestartScreen_testErrorMeetingNotExists() {
+      assertThrows(
+          VideoServerException.class,
+          () ->
+              videoServerService.iceRestartScreen(
+                  user1Id.toString(), meeting1Id.toString(), "session-description-protocol"),
+          "No videoserver meeting found for the meeting " + meeting1Id);
+
+      verify(videoServerMeetingRepository, times(1)).getById(meeting1Id.toString());
+    }
+
+    @Test
+    @DisplayName(
+        "Try to trigger ice restart for screen stream on a meeting of a participant that is not in")
+    void iceRestartScreen_testErrorParticipantNotExists() {
+      createVideoServerMeeting(meeting1Id);
+
+      assertThrows(
+          VideoServerException.class,
+          () ->
+              videoServerService.iceRestartScreen(
+                  user1Id.toString(), meeting1Id.toString(), "session-description-protocol"),
+          "No Videoserver session found for user " + user1Id + " for the meeting " + meeting1Id);
+
+      verify(videoServerMeetingRepository, times(1)).getById(meeting1Id.toString());
+    }
+
+    @Test
+    @DisplayName(
+        "Try to trigger ice restart for screen stream on a meeting but video server returns error")
+    void iceRestartScreen_testErrorResponseFromVideoServer() {
+      VideoServerMeeting videoServerMeeting = createVideoServerMeeting(meeting1Id);
+      VideoServerSession videoServerSession =
+          VideoServerSession.create()
+              .userId(user1Id.toString())
+              .queueId(queue1Id.toString())
+              .videoServerMeeting(videoServerMeeting)
+              .connectionId(user1SessionId.toString())
+              .screenHandleId(user1ScreenHandleId.toString());
+      videoServerMeeting.videoServerSessions(List.of(videoServerSession));
+
+      VideoRoomResponse iceRestartScreenResponse = VideoRoomResponse.create().status("error");
+      when(videoServerClient.sendVideoRoomRequest(
+              eq(user1SessionId.toString()),
+              eq(user1ScreenHandleId.toString()),
+              any(VideoServerMessageRequest.class)))
+          .thenReturn(iceRestartScreenResponse);
+
+      assertThrows(
+          VideoServerException.class,
+          () ->
+              videoServerService.iceRestartScreen(
+                  user1Id.toString(), meeting1Id.toString(), "session-description-protocol"),
+          "An error occurred while user "
+              + user1Id
+              + " with connection id "
+              + queue1Id
+              + " is triggering screen ice restart");
+
+      verify(videoServerMeetingRepository, times(1)).getById(meeting1Id.toString());
+      verify(videoServerClient, times(1))
+          .sendVideoRoomRequest(
+              eq(user1SessionId.toString()),
+              eq(user1ScreenHandleId.toString()),
+              any(VideoServerMessageRequest.class));
+    }
+  }
+
+  @Nested
   @DisplayName("Health check tests")
   class HealthCheckTests {
 

--- a/carbonio-ws-collaboration-openapi/src/main/resources/api.yaml
+++ b/carbonio-ws-collaboration-openapi/src/main/resources/api.yaml
@@ -6,9 +6,10 @@ openapi: 3.0.3
 info:
   title: Zextras Carbonio Workstream Collaboration API
   description: Zextras Carbonio Workstream Collaboration HTTP APIs definition.
-  version: 1.6.12
+  version: 1.6.13
   x-supported-versions:
     [
+      "1.6.13",
       "1.6.12",
       "1.6.11",
       "1.6.10",
@@ -935,6 +936,25 @@ paths:
           $ref: '#/components/responses/403ForbiddenResponse'
         404:
           $ref: '#/components/responses/404NotFoundResponse'
+  /meetings/{meetingId}/screen/iceRestart:
+    put:
+      tags:
+        - Meetings
+      summary: Start WebRTC negotiation for screen stream for the current session on ICE restart
+      operationId: iceRestartScreen
+      parameters:
+        - $ref: '#/components/parameters/pathMeetingId'
+      requestBody:
+        $ref: '#/components/requestBodies/RtcMediaStreamRequest'
+      responses:
+        204:
+          $ref: '#/components/responses/204IceRestartScreenStreamResponse'
+        401:
+          $ref: '#/components/responses/401UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/403ForbiddenResponse'
+        404:
+          $ref: '#/components/responses/404NotFoundResponse'
   /meetings/{meetingId}/hand:
     put:
       tags:
@@ -1552,6 +1572,8 @@ components:
       description: The offer related to the audio stream has been processed and sent successfully on ICE restart
     204IceRestartVideoStreamResponse:
       description: The offer related to the video stream has been processed and sent successfully on ICE restart
+    204IceRestartScreenStreamResponse:
+      description: The offer related to the screen stream has been processed and sent successfully on ICE restart
     204MediaStreamResponse:
       description: The status of media stream changed successfully
     204AnswerMediaStreamResponse:

--- a/carbonio-ws-collaboration-openapi/src/main/resources/asyncapi.yaml
+++ b/carbonio-ws-collaboration-openapi/src/main/resources/asyncapi.yaml
@@ -5,12 +5,13 @@
 openapi: 3.0.3
 info:
   title: Events Data Models
-  version: 1.6.12
+  version: 1.6.13
   description: |
     Data models for room and meeting events.
     This specification contains only the schemas for code generation purposes.
   x-supported-versions:
     [
+      "1.6.13",
       "1.6.12",
       "1.6.11",
       "1.6.10",


### PR DESCRIPTION
Introduce a new endpoint to trigger WebRTC ICE restart for screen-sharing streams in meetings. This addition mirrors the existing video ICE restart functionality and includes necessary updates to the API versioning and documentation.