### PR TITLE
feat(ci): [IN-951] add arm64 platform to docker image builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,6 +145,7 @@ pipeline {
                 dockerStage([
                     dockerfile: 'docker/wsc/Dockerfile',
                     imageName: 'carbonio-ws-collaboration-ce',
+                    platforms: ['linux/amd64', 'linux/arm64'] as Set,
                     ocLabels: [
                         title: 'Carbonio WS Collaboration CE',
                         description: 'Carbonio WS Collaboration CE'


### PR DESCRIPTION
Adds `platforms: ['linux/amd64', 'linux/arm64'] as Set` to each `dockerStage` call so images build for arm64 (Apple Silicon / MacOS) in addition to amd64.

Mirrors the merged carbonio-mailbox pattern (PR #994). The `as Set` cast is required: dockerHelper only emits `--platform` when platforms is a Set.

Ref: IN-951