### PR TITLE
fix(reuse): project-owned REUSE.toml

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -116,9 +116,3 @@ path = "docs/websocket-events.md"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 Zextras"
 SPDX-License-Identifier = "AGPL-3.0-only"
-
-[[annotations]]
-path = "**"
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2026 Zextras <https://www.zextras.com>"
-SPDX-License-Identifier = "AGPL-3.0-only"


### PR DESCRIPTION
Devel reuse lint (verify mode) was failing after the dt3-pipeline merge. This makes REUSE.toml project-owned: removes the lib's path=** catch-all, migrates+removes legacy .reuse/dep5, completes LICENSES/, and covers excluded/pinned paths (Flyway migrations, package/) via annotations WITHOUT modifying them. reuse lint (fsfe/reuse:5.0.2) passes locally.