### PR TITLE
fix(deps): bump preview SDK to 2.0.2-1

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -1,6 +1,9 @@
 AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
 
   Carbonio Systemd Notify (com.zextras.carbonio:carbonio-systemd-notify:1.0.1)
+  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.0.3-dev.21.79fc3fa2)
+  filestore-sdk-common (com.zextras:filestore-sdk-common:0.0.15-20251106.164324-4)
+  storages-ce-sdk (com.zextras:storages-ce-sdk:0.0.15-20251106.164324-4)
 
 Apache Software License, version 2.0 (https://spdx.org/licenses/Apache Software License, version 2.0.html) applies to:
 
@@ -19,6 +22,7 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   Apache Commons Logging (commons-logging:commons-logging:1.2)
   Apache Commons Text (org.apache.commons:commons-text:1.12.0)
   Apache HttpClient (org.apache.httpcomponents:httpclient:4.5.14)
+  Apache HttpClient Mime (org.apache.httpcomponents:httpmime:4.5.14)
   Apache HttpCore (org.apache.httpcomponents:httpcore:4.4.16)
   Apache James :: Mime4j :: Core (org.apache.james:apache-mime4j-core:0.8.11)
   Apache James :: Mime4j :: DOM (org.apache.james:apache-mime4j-dom:0.8.11)
@@ -36,6 +40,7 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   classpath-scanner (io.avaje:classpath-scanner:7.1)
   classpath-scanner-api (io.avaje:classpath-scanner-api:7.1)
   consul-client (com.orbitz.consul:consul-client:1.5.3)
+  Converter: Gson (com.squareup.retrofit2:converter-gson:2.9.0)
   Converter: Jackson (com.squareup.retrofit2:converter-jackson:2.9.0)
   Core :: ALPN :: Client (org.eclipse.jetty:jetty-alpn-client:12.0.19)
   Core :: EE Common (org.eclipse.jetty:jetty-ee:12.0.19)
@@ -95,6 +100,9 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   io.grpc:grpc-context (io.grpc:grpc-context:1.73.0)
   io.grpc:grpc-core (io.grpc:grpc-core:1.73.0)
   io.grpc:grpc-netty-shaded (io.grpc:grpc-netty-shaded:1.73.0)
+  io.grpc:grpc-protobuf (io.grpc:grpc-protobuf:1.79.0)
+  io.grpc:grpc-protobuf-lite (io.grpc:grpc-protobuf-lite:1.79.0)
+  io.grpc:grpc-stub (io.grpc:grpc-stub:1.79.0)
   io.grpc:grpc-util (io.grpc:grpc-util:1.73.0)
   J2ObjC Annotations (com.google.j2objc:j2objc-annotations:1.3)
   J2ObjC Annotations (com.google.j2objc:j2objc-annotations:3.0.0)
@@ -122,6 +130,7 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   okhttp (com.squareup.okhttp3:okhttp:4.9.0)
   Okio (com.squareup.okio:okio:2.8.0)
   perfmark:perfmark-api (io.perfmark:perfmark-api:0.27.0)
+  proto-google-common-protos (com.google.api.grpc:proto-google-common-protos:2.63.2)
   RabbitMQ Java Client (com.rabbitmq:amqp-client:5.22.0)
   Reflections (org.reflections:reflections:0.10.2)
   RESTEasy Client (org.jboss.resteasy:resteasy-client:7.0.0.Alpha2)
@@ -138,9 +147,12 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   Retrofit (com.squareup.retrofit2:retrofit:2.9.0)
   SnakeYAML (org.yaml:snakeyaml:2.4)
   swagger-annotations (io.swagger:swagger-annotations:1.6.14)
+  swagger-annotations-jakarta (io.swagger.core.v3:swagger-annotations-jakarta:2.2.22)
   swagger-core (io.swagger:swagger-core:1.6.14)
   swagger-jaxrs (io.swagger:swagger-jaxrs:1.6.14)
   swagger-models (io.swagger:swagger-models:1.6.14)
+  Vavr (io.vavr:vavr:0.11.0)
+  Vavr Match (io.vavr:vavr-match:0.11.0)
 
 BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause.html) applies to:
 
@@ -151,6 +163,11 @@ BSD-3-Clause (https://spdx.org/licenses/BSD-3-Clause.html) applies to:
   asm (org.ow2.asm:asm:9.7.1)
   asm-commons (org.ow2.asm:asm-commons:9.7.1)
   asm-tree (org.ow2.asm:asm-tree:9.7.1)
+  Protocol Buffers [Core] (com.google.protobuf:protobuf-java:4.33.2)
+
+CDDL + GPLv2 with classpath exception (https://spdx.org/licenses/CDDL + GPLv2 with classpath exception.html) applies to:
+
+  javax.annotation API (javax.annotation:javax.annotation-api:1.3.2)
 
 CDDL License (https://spdx.org/licenses/CDDL License.html) applies to:
 
@@ -169,6 +186,7 @@ EPL-2.0 (https://spdx.org/licenses/EPL-2.0.html) applies to:
 
   Angus Mail Provider (org.eclipse.angus:angus-mail:1.1.0)
   Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:2.1.1)
+  Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:3.0.0)
   Jakarta Interceptors (jakarta.interceptor:jakarta.interceptor-api:2.1.0)
   Jakarta Mail API (jakarta.mail:jakarta.mail-api:2.1.2)
   Jakarta RESTful WS API (jakarta.ws.rs:jakarta.ws.rs-api:4.0.0)
@@ -247,6 +265,7 @@ GPL2 w/ CPE (https://spdx.org/licenses/GPL2 w/ CPE.html) applies to:
 
   Angus Mail Provider (org.eclipse.angus:angus-mail:1.1.0)
   Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:2.1.1)
+  Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:3.0.0)
   Jakarta Interceptors (jakarta.interceptor:jakarta.interceptor-api:2.1.0)
   Jakarta Mail API (jakarta.mail:jakarta.mail-api:2.1.2)
   Jakarta Servlet (jakarta.servlet:jakarta.servlet-api:6.0.0)
@@ -297,8 +316,13 @@ Public Domain (https://spdx.org/licenses/Public Domain.html) applies to:
 
 The Apache License, Version 2.0 (https://spdx.org/licenses/The Apache License, Version 2.0.html) applies to:
 
+  JSpecify annotations (org.jspecify:jspecify:1.0.0)
   org.jetbrains.kotlin:kotlin-stdlib (org.jetbrains.kotlin:kotlin-stdlib:1.4.10)
   org.jetbrains.kotlin:kotlin-stdlib-common (org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0)
+
+Unknown license (https://spdx.org/licenses/Unknown license.html) applies to:
+
+  Carbonio Preview CE - REST SDK (com.zextras.carbonio.preview:carbonio-preview-ce-rest-sdk:2.0.2-1)
 
 WTFPL (https://spdx.org/licenses/WTFPL.html) applies to:
 

--- a/carbonio-ws-collaboration-core/pom.xml
+++ b/carbonio-ws-collaboration-core/pom.xml
@@ -48,7 +48,13 @@ SPDX-License-Identifier: AGPL-3.0-only
         <!-- Previewer sdk -->
         <dependency>
             <groupId>com.zextras.carbonio.preview</groupId>
-            <artifactId>carbonio-preview-sdk</artifactId>
+            <artifactId>carbonio-preview-ce-rest-sdk</artifactId>
+        </dependency>
+
+        <!-- Vavr: no longer transitively provided by the preview SDK, used directly here -->
+        <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
         </dependency>
 
         <!-- Jetty dependencies -->

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/config/module/CoreModule.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/config/module/CoreModule.java
@@ -128,7 +128,7 @@ import com.zextras.carbonio.chats.core.web.socket.SessionPingManager;
 import com.zextras.carbonio.chats.core.web.socket.VideoServerEventListener;
 import com.zextras.carbonio.chats.core.web.socket.versioning.WebsocketVersionMigrator;
 import com.zextras.carbonio.chats.core.web.utility.HttpClient;
-import com.zextras.carbonio.preview.PreviewClient;
+import com.zextras.carbonio.preview.sdk.PreviewClient;
 import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc;
 import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc.UserManagementServiceBlockingStub;
 import com.zextras.storages.api.StoragesClient;

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/preview/PreviewService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/preview/PreviewService.java
@@ -10,9 +10,6 @@ import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
 import com.zextras.carbonio.chats.model.ImageQualityEnumDto;
 import com.zextras.carbonio.chats.model.ImageShapeEnumDto;
 import com.zextras.carbonio.chats.model.ImageTypeEnumDto;
-import com.zextras.carbonio.preview.queries.enums.Format;
-import com.zextras.carbonio.preview.queries.enums.Quality;
-import com.zextras.carbonio.preview.queries.enums.Shape;
 import io.vavr.control.Option;
 import java.util.UUID;
 
@@ -27,8 +24,8 @@ public interface PreviewService extends HealthIndicator {
    * @param user the user trying to access the preview attachment
    * @param fileId identifier of attachment file to preview {@link UUID}
    * @param area area ot preview in format widthXheight
-   * @param quality the quality of the preview {@link Quality}
-   * @param outputFormat the format of the preview {@link Format}
+   * @param quality the quality of the preview
+   * @param outputFormat the format of the preview
    * @param crop if true will crop borders, otherwise will fill them
    * @return the preview requested with necessary data {@link FileResponse}
    */
@@ -40,9 +37,9 @@ public interface PreviewService extends HealthIndicator {
    * @param user the user trying to access the preview attachment
    * @param fileId identifier of attachment file to preview {@link UUID}
    * @param area area ot preview in format widthXheight
-   * @param quality the quality of the preview {@link Quality}
-   * @param outputFormat the format of the preview {@link Format}
-   * @param shape rounded or rectangular are supported {@link Shape}
+   * @param quality the quality of the preview
+   * @param outputFormat the format of the preview
+   * @param shape rounded or rectangular are supported
    * @return the preview requested with necessary data {@link FileResponse}
    */
   FileResponse getImageThumbnail(UserPrincipal user, UUID fileId, String area, Option<ImageQualityEnumDto> quality, Option<ImageTypeEnumDto> outputFormat, Option<ImageShapeEnumDto> shape);
@@ -63,9 +60,9 @@ public interface PreviewService extends HealthIndicator {
    * @param user the user trying to access the preview attachment
    * @param fileId identifier of attachment file to preview {@link UUID}
    * @param area area ot preview in format widthXheight
-   * @param quality the quality of the preview {@link Quality}
-   * @param outputFormat the format of the preview {@link Format}
-   * @param shape rounded or rectangular are supported {@link Shape}
+   * @param quality the quality of the preview
+   * @param outputFormat the format of the preview
+   * @param shape rounded or rectangular are supported
    * @return the preview requested with necessary data {@link FileResponse}
    */
   FileResponse getPDFThumbnail(UserPrincipal user, UUID fileId, String area, Option<ImageQualityEnumDto> quality, Option<ImageTypeEnumDto> outputFormat, Option<ImageShapeEnumDto> shape);

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/preview/impl/PreviewServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/preview/impl/PreviewServiceImpl.java
@@ -16,17 +16,17 @@ import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
 import com.zextras.carbonio.chats.model.ImageQualityEnumDto;
 import com.zextras.carbonio.chats.model.ImageShapeEnumDto;
 import com.zextras.carbonio.chats.model.ImageTypeEnumDto;
-import com.zextras.carbonio.preview.PreviewClient;
-import com.zextras.carbonio.preview.queries.BlobResponse;
-import com.zextras.carbonio.preview.queries.Query;
-import com.zextras.carbonio.preview.queries.enums.ServiceType;
+import com.zextras.carbonio.preview.sdk.PreviewClient;
+import com.zextras.carbonio.preview.sdk.PreviewResponse;
+import com.zextras.carbonio.preview.sdk.QueryBuilder;
 import io.vavr.control.Option;
-import io.vavr.control.Try;
 
 import java.util.UUID;
 
 @Singleton
 public class PreviewServiceImpl implements PreviewService {
+
+  private static final String SERVICE_TYPE_CHATS = "chats";
 
   private final PreviewClient previewClient;
 
@@ -44,16 +44,12 @@ public class PreviewServiceImpl implements PreviewService {
     this.fileMetadataRepository = fileMetadataRepository;
   }
 
-  private FileResponse remapBlobToDataFile(Try<BlobResponse> response) {
-    return response
-        .map(
-            bResp ->
-                Try.of(
-                        () ->
-                            new FileResponse(
-                                bResp.getContent(), bResp.getLength(), bResp.getMimeType()))
-                    .getOrElseThrow(t -> new PreviewException(t)))
-        .getOrElseThrow(t -> new PreviewException(t));
+  private FileResponse remapPreviewResponse(PreviewResponse response) {
+    try {
+      return new FileResponse(response.getContent(), response.getLength(), response.getMimeType());
+    } catch (Exception t) {
+      throw new PreviewException(t);
+    }
   }
 
   @Override
@@ -67,18 +63,22 @@ public class PreviewServiceImpl implements PreviewService {
     FileMetadata metadata = getValidMetadata(fileId);
     roomService.getRoomAndValidateUser(UUID.fromString(metadata.getRoomId()), user, false);
 
-    Query.QueryBuilder parameters =
-        new Query.QueryBuilder()
-            .setFileOwnerId(metadata.getUserId())
-            .setServiceType(ServiceType.CHATS)
-            .setFileId(fileId.toString())
-            .setVersion(0)
-            .setPreviewArea(area);
-    quality.map(q -> parameters.setQuality(q.toString().toUpperCase()));
-    outputFormat.map(f -> parameters.setOutputFormat(f.toString().toUpperCase()));
-    crop.map(parameters::setCrop);
+    QueryBuilder parameters =
+        new QueryBuilder()
+            .ownerId(metadata.getUserId())
+            .serviceType(SERVICE_TYPE_CHATS)
+            .fileId(fileId.toString())
+            .version(0)
+            .area(area);
+    quality.forEach(q -> parameters.quality(q.toString().toLowerCase()));
+    outputFormat.forEach(f -> parameters.outputFormat(f.toString().toLowerCase()));
+    crop.forEach(parameters::crop);
 
-    return remapBlobToDataFile(previewClient.getPreviewOfImage(parameters.build()));
+    try {
+      return remapPreviewResponse(previewClient.getPreviewOfImage(parameters.build()));
+    } catch (com.zextras.carbonio.preview.sdk.PreviewException e) {
+      throw new PreviewException(e);
+    }
   }
 
   @Override
@@ -92,18 +92,22 @@ public class PreviewServiceImpl implements PreviewService {
     FileMetadata metadata = getValidMetadata(fileId);
     roomService.getRoomAndValidateUser(UUID.fromString(metadata.getRoomId()), user, false);
 
-    Query.QueryBuilder parameters =
-        new Query.QueryBuilder()
-            .setFileOwnerId(metadata.getUserId())
-            .setServiceType(ServiceType.CHATS)
-            .setFileId(fileId.toString())
-            .setVersion(0)
-            .setPreviewArea(area);
-    quality.map(q -> parameters.setQuality(q.toString().toUpperCase()));
-    outputFormat.map(f -> parameters.setOutputFormat(f.toString().toUpperCase()));
-    shape.map(s -> parameters.setShape(s.toString().toUpperCase()));
+    QueryBuilder parameters =
+        new QueryBuilder()
+            .ownerId(metadata.getUserId())
+            .serviceType(SERVICE_TYPE_CHATS)
+            .fileId(fileId.toString())
+            .version(0)
+            .area(area);
+    quality.forEach(q -> parameters.quality(q.toString().toLowerCase()));
+    outputFormat.forEach(f -> parameters.outputFormat(f.toString().toLowerCase()));
+    shape.forEach(s -> parameters.shape(s.toString().toLowerCase()));
 
-    return remapBlobToDataFile(previewClient.getThumbnailOfImage(parameters.build()));
+    try {
+      return remapPreviewResponse(previewClient.getThumbnailOfImage(parameters.build()));
+    } catch (com.zextras.carbonio.preview.sdk.PreviewException e) {
+      throw new PreviewException(e);
+    }
   }
 
   @Override
@@ -111,16 +115,20 @@ public class PreviewServiceImpl implements PreviewService {
     FileMetadata metadata = getValidMetadata(fileId);
     roomService.getRoomAndValidateUser(UUID.fromString(metadata.getRoomId()), user, false);
 
-    Query.QueryBuilder parameters =
-        new Query.QueryBuilder()
-            .setFileOwnerId(metadata.getUserId())
-            .setServiceType(ServiceType.CHATS)
-            .setFileId(fileId.toString())
-            .setVersion(0);
-    Option.of(firstPage).peek(parameters::setFirstPage);
-    Option.of(lastPage).peek(parameters::setLastPage);
+    QueryBuilder parameters =
+        new QueryBuilder()
+            .ownerId(metadata.getUserId())
+            .serviceType(SERVICE_TYPE_CHATS)
+            .fileId(fileId.toString())
+            .version(0);
+    Option.of(firstPage).forEach(parameters::firstPage);
+    Option.of(lastPage).forEach(parameters::lastPage);
 
-    return remapBlobToDataFile(previewClient.getPreviewOfPdf(parameters.build()));
+    try {
+      return remapPreviewResponse(previewClient.getPreviewOfPdf(parameters.build()));
+    } catch (com.zextras.carbonio.preview.sdk.PreviewException e) {
+      throw new PreviewException(e);
+    }
   }
 
   @Override
@@ -134,18 +142,22 @@ public class PreviewServiceImpl implements PreviewService {
     FileMetadata metadata = getValidMetadata(fileId);
     roomService.getRoomAndValidateUser(UUID.fromString(metadata.getRoomId()), user, false);
 
-    Query.QueryBuilder parameters =
-        new Query.QueryBuilder()
-            .setFileOwnerId(metadata.getUserId())
-            .setServiceType(ServiceType.CHATS)
-            .setFileId(fileId.toString())
-            .setVersion(0)
-            .setPreviewArea(area);
-    quality.map(q -> parameters.setQuality(q.toString().toUpperCase()));
-    outputFormat.map(f -> parameters.setOutputFormat(f.toString().toUpperCase()));
-    shape.map(s -> parameters.setShape(s.toString().toUpperCase()));
+    QueryBuilder parameters =
+        new QueryBuilder()
+            .ownerId(metadata.getUserId())
+            .serviceType(SERVICE_TYPE_CHATS)
+            .fileId(fileId.toString())
+            .version(0)
+            .area(area);
+    quality.forEach(q -> parameters.quality(q.toString().toLowerCase()));
+    outputFormat.forEach(f -> parameters.outputFormat(f.toString().toLowerCase()));
+    shape.forEach(s -> parameters.shape(s.toString().toLowerCase()));
 
-    return remapBlobToDataFile(previewClient.getThumbnailOfPdf(parameters.build()));
+    try {
+      return remapPreviewResponse(previewClient.getThumbnailOfPdf(parameters.build()));
+    } catch (com.zextras.carbonio.preview.sdk.PreviewException e) {
+      throw new PreviewException(e);
+    }
   }
 
   private FileMetadata getValidMetadata(UUID fileId) {

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/preview/impl/PreviewServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/preview/impl/PreviewServiceImplTest.java
@@ -29,15 +29,10 @@ import com.zextras.carbonio.chats.model.ImageQualityEnumDto;
 import com.zextras.carbonio.chats.model.ImageShapeEnumDto;
 import com.zextras.carbonio.chats.model.ImageTypeEnumDto;
 import com.zextras.carbonio.chats.model.RoomTypeDto;
-import com.zextras.carbonio.preview.PreviewClient;
-import com.zextras.carbonio.preview.queries.BlobResponse;
-import com.zextras.carbonio.preview.queries.Query;
-import com.zextras.carbonio.preview.queries.enums.Format;
-import com.zextras.carbonio.preview.queries.enums.Quality;
-import com.zextras.carbonio.preview.queries.enums.ServiceType;
-import com.zextras.carbonio.preview.queries.enums.Shape;
+import com.zextras.carbonio.preview.sdk.PreviewClient;
+import com.zextras.carbonio.preview.sdk.PreviewResponse;
+import com.zextras.carbonio.preview.sdk.Query;
 import io.vavr.control.Option;
-import io.vavr.control.Try;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
@@ -101,24 +96,10 @@ class PreviewServiceImplTest {
         .thenReturn(Optional.of(expectedMetadata));
     when(roomService.getRoomAndValidateUser(UUID.fromString(room1.getId()), currentUser, false))
         .thenReturn(room1);
-    Query parameters =
-        new Query.QueryBuilder()
-            .setFileOwnerId(user1Id.toString())
-            .setServiceType(ServiceType.CHATS)
-            .setFileId(fileId.toString())
-            .setVersion(0)
-            .setPreviewArea("100x100")
-            .setQuality(Quality.HIGH)
-            .setOutputFormat(Format.JPEG)
-            .setCrop(false)
-            .build();
-    BlobResponse mockBlobResponse = mock(BlobResponse.class);
-    when(mockBlobResponse.getContent()).thenReturn(new ByteArrayInputStream("image".getBytes()));
-    when(mockBlobResponse.getLength()).thenReturn(5L);
-    when(mockBlobResponse.getMimeType()).thenReturn("image/jpeg");
+    PreviewResponse mockPreviewResponse =
+        new PreviewResponse(new ByteArrayInputStream("image".getBytes()), 5L, "image/jpeg");
     ArgumentCaptor<Query> parametersCapture = ArgumentCaptor.forClass(Query.class);
-    when(previewClient.getPreviewOfImage(any(Query.class)))
-        .thenReturn(Try.success(mockBlobResponse));
+    when(previewClient.getPreviewOfImage(any(Query.class))).thenReturn(mockPreviewResponse);
     FileResponse previewImageResponse =
         previewService.getImage(
             currentUser,
@@ -129,7 +110,15 @@ class PreviewServiceImplTest {
             Option.of(false));
 
     verify(previewClient, times(1)).getPreviewOfImage(parametersCapture.capture());
-    assertEquals(parametersCapture.getValue().toString(), parameters.toString());
+    Query captured = parametersCapture.getValue();
+    assertEquals(user1Id.toString(), captured.getOwnerId());
+    assertEquals("chats", captured.getServiceType());
+    assertEquals(fileId.toString(), captured.getFileId());
+    assertEquals(0, captured.getVersion());
+    assertEquals("100x100", captured.getArea());
+    assertEquals("high", captured.getQuality());
+    assertEquals("jpeg", captured.getOutputFormat());
+    assertEquals(false, captured.isCrop());
     assertEquals("image", new String(previewImageResponse.getContent().readAllBytes()));
     assertEquals(5, previewImageResponse.getLength());
     assertEquals("image/jpeg", previewImageResponse.getMimeType());
@@ -153,24 +142,10 @@ class PreviewServiceImplTest {
         .thenReturn(Optional.of(expectedMetadata));
     when(roomService.getRoomAndValidateUser(UUID.fromString(room1.getId()), currentUser, false))
         .thenReturn(room1);
-    Query parameters =
-        new Query.QueryBuilder()
-            .setFileOwnerId(user1Id.toString())
-            .setServiceType(ServiceType.CHATS)
-            .setFileId(fileId.toString())
-            .setVersion(0)
-            .setPreviewArea("100x100")
-            .setQuality(Quality.HIGH)
-            .setOutputFormat(Format.JPEG)
-            .setShape(Shape.RECTANGULAR)
-            .build();
-    BlobResponse mockBlobResponse = mock(BlobResponse.class);
-    when(mockBlobResponse.getContent()).thenReturn(new ByteArrayInputStream("image".getBytes()));
-    when(mockBlobResponse.getLength()).thenReturn(5L);
-    when(mockBlobResponse.getMimeType()).thenReturn("image/jpeg");
+    PreviewResponse mockPreviewResponse =
+        new PreviewResponse(new ByteArrayInputStream("image".getBytes()), 5L, "image/jpeg");
     ArgumentCaptor<Query> parametersCapture = ArgumentCaptor.forClass(Query.class);
-    when(previewClient.getThumbnailOfImage(any(Query.class)))
-        .thenReturn(Try.success(mockBlobResponse));
+    when(previewClient.getThumbnailOfImage(any(Query.class))).thenReturn(mockPreviewResponse);
     FileResponse previewImageResponse =
         previewService.getImageThumbnail(
             currentUser,
@@ -181,9 +156,17 @@ class PreviewServiceImplTest {
             Option.of(ImageShapeEnumDto.RECTANGULAR));
 
     verify(previewClient, times(1)).getThumbnailOfImage(parametersCapture.capture());
-    assertEquals(parametersCapture.getValue().toString(), parameters.toString());
+    Query captured = parametersCapture.getValue();
+    assertEquals(user1Id.toString(), captured.getOwnerId());
+    assertEquals("chats", captured.getServiceType());
+    assertEquals(fileId.toString(), captured.getFileId());
+    assertEquals(0, captured.getVersion());
+    assertEquals("100x100", captured.getArea());
+    assertEquals("high", captured.getQuality());
+    assertEquals("jpeg", captured.getOutputFormat());
+    assertEquals("rectangular", captured.getShape());
     assertEquals("image", new String(previewImageResponse.getContent().readAllBytes()));
-    assertEquals(5, previewImageResponse.getLength(), 5);
+    assertEquals(5, previewImageResponse.getLength());
     assertEquals("image/jpeg", previewImageResponse.getMimeType());
   }
 
@@ -205,27 +188,22 @@ class PreviewServiceImplTest {
         .thenReturn(Optional.of(expectedMetadata));
     when(roomService.getRoomAndValidateUser(UUID.fromString(room1.getId()), currentUser, false))
         .thenReturn(room1);
-    Query parameters =
-        new Query.QueryBuilder()
-            .setFileOwnerId(user1Id.toString())
-            .setServiceType(ServiceType.CHATS)
-            .setFileId(fileId.toString())
-            .setVersion(0)
-            .setFirstPage(1)
-            .setLastPage(0)
-            .build();
-    BlobResponse mockBlobResponse = mock(BlobResponse.class);
-    when(mockBlobResponse.getContent()).thenReturn(new ByteArrayInputStream("pdf".getBytes()));
-    when(mockBlobResponse.getLength()).thenReturn(3L);
-    when(mockBlobResponse.getMimeType()).thenReturn("application/pdf");
+    PreviewResponse mockPreviewResponse =
+        new PreviewResponse(new ByteArrayInputStream("pdf".getBytes()), 3L, "application/pdf");
     ArgumentCaptor<Query> parametersCapture = ArgumentCaptor.forClass(Query.class);
-    when(previewClient.getPreviewOfPdf(any(Query.class))).thenReturn(Try.success(mockBlobResponse));
+    when(previewClient.getPreviewOfPdf(any(Query.class))).thenReturn(mockPreviewResponse);
     FileResponse previewImageResponse = previewService.getPDF(currentUser, fileId, 1, 0);
 
     verify(previewClient, times(1)).getPreviewOfPdf(parametersCapture.capture());
-    assertEquals(parametersCapture.getValue().toString(), parameters.toString());
+    Query captured = parametersCapture.getValue();
+    assertEquals(user1Id.toString(), captured.getOwnerId());
+    assertEquals("chats", captured.getServiceType());
+    assertEquals(fileId.toString(), captured.getFileId());
+    assertEquals(0, captured.getVersion());
+    assertEquals(1, captured.getFirstPage());
+    assertEquals(0, captured.getLastPage());
     assertEquals("pdf", new String(previewImageResponse.getContent().readAllBytes()));
-    assertEquals(3, previewImageResponse.getLength(), 3);
+    assertEquals(3, previewImageResponse.getLength());
     assertEquals("application/pdf", previewImageResponse.getMimeType());
   }
 
@@ -247,24 +225,10 @@ class PreviewServiceImplTest {
         .thenReturn(Optional.of(expectedMetadata));
     when(roomService.getRoomAndValidateUser(UUID.fromString(room1.getId()), currentUser, false))
         .thenReturn(room1);
-    Query parameters =
-        new Query.QueryBuilder()
-            .setFileOwnerId(user1Id.toString())
-            .setServiceType(ServiceType.CHATS)
-            .setFileId(fileId.toString())
-            .setVersion(0)
-            .setPreviewArea("100x100")
-            .setQuality(Quality.HIGH)
-            .setOutputFormat(Format.JPEG)
-            .setShape(Shape.RECTANGULAR)
-            .build();
-    BlobResponse mockBlobResponse = mock(BlobResponse.class);
-    when(mockBlobResponse.getContent()).thenReturn(new ByteArrayInputStream("pdf".getBytes()));
-    when(mockBlobResponse.getLength()).thenReturn(3L);
-    when(mockBlobResponse.getMimeType()).thenReturn("application/pdf");
+    PreviewResponse mockPreviewResponse =
+        new PreviewResponse(new ByteArrayInputStream("pdf".getBytes()), 3L, "application/pdf");
     ArgumentCaptor<Query> parametersCapture = ArgumentCaptor.forClass(Query.class);
-    when(previewClient.getThumbnailOfPdf(any(Query.class)))
-        .thenReturn(Try.success(mockBlobResponse));
+    when(previewClient.getThumbnailOfPdf(any(Query.class))).thenReturn(mockPreviewResponse);
     FileResponse previewImageResponse =
         previewService.getPDFThumbnail(
             currentUser,
@@ -275,9 +239,17 @@ class PreviewServiceImplTest {
             Option.of(ImageShapeEnumDto.RECTANGULAR));
 
     verify(previewClient, times(1)).getThumbnailOfPdf(parametersCapture.capture());
-    assertEquals(parametersCapture.getValue().toString(), parameters.toString());
+    Query captured = parametersCapture.getValue();
+    assertEquals(user1Id.toString(), captured.getOwnerId());
+    assertEquals("chats", captured.getServiceType());
+    assertEquals(fileId.toString(), captured.getFileId());
+    assertEquals(0, captured.getVersion());
+    assertEquals("100x100", captured.getArea());
+    assertEquals("high", captured.getQuality());
+    assertEquals("jpeg", captured.getOutputFormat());
+    assertEquals("rectangular", captured.getShape());
     assertEquals("pdf", new String(previewImageResponse.getContent().readAllBytes()));
-    assertEquals(3, previewImageResponse.getLength(), 3);
+    assertEquals(3, previewImageResponse.getLength());
     assertEquals("application/pdf", previewImageResponse.getMimeType());
   }
 
@@ -331,7 +303,7 @@ class PreviewServiceImplTest {
     when(roomService.getRoomAndValidateUser(UUID.fromString(room1.getId()), currentUser, false))
         .thenReturn(room1);
     when(previewClient.getPreviewOfImage(any(Query.class)))
-        .thenReturn(Try.failure(new RuntimeException()));
+        .thenThrow(new com.zextras.carbonio.preview.sdk.PreviewException(500, "server error"));
     assertThrows(
         PreviewException.class,
         () ->

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/web/api/PreviewApiIT.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/web/api/PreviewApiIT.java
@@ -24,9 +24,6 @@ import com.zextras.carbonio.chats.model.ImageQualityEnumDto;
 import com.zextras.carbonio.chats.model.ImageShapeEnumDto;
 import com.zextras.carbonio.chats.model.ImageTypeEnumDto;
 import com.zextras.carbonio.chats.model.RoomTypeDto;
-import com.zextras.carbonio.preview.queries.enums.Format;
-import com.zextras.carbonio.preview.queries.enums.Quality;
-import com.zextras.carbonio.preview.queries.enums.Shape;
 import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.util.List;
@@ -94,7 +91,7 @@ class PreviewApiIT {
   class PreviewImageTests {
 
     private HttpRequest mockGetPreviewImageRequest(
-        String fileId, String area, Quality quality, Format format, Boolean crop) {
+        String fileId, String area, String quality, String format, Boolean crop) {
       HttpRequest request =
           request()
               .withMethod("GET")
@@ -102,22 +99,23 @@ class PreviewApiIT {
               .withPathParameter("fileId", fileId)
               .withPathParameter("area", area)
               .withQueryStringParameter(param("service_type", "chats"));
-      if (crop != null)
-        request.withQueryStringParameter(param("crop", crop.toString().toLowerCase()));
+      // The REST preview SDK only emits crop=true; when crop is false/absent it sends no crop
+      // query param at all (see PreviewClient#buildImageQueryString), so only stub it when true.
+      if (Boolean.TRUE.equals(crop)) request.withQueryStringParameter(param("crop", "true"));
       if (quality != null)
-        request.withQueryStringParameter(param("quality", quality.toString().toLowerCase()));
+        request.withQueryStringParameter(param("quality", quality.toLowerCase()));
       if (format != null)
-        request.withQueryStringParameter(param("output_format", format.toString().toLowerCase()));
+        request.withQueryStringParameter(param("output_format", format.toLowerCase()));
       return request;
     }
 
     private HttpResponse mockGetPreviewImageResponse(
-        Format format, Integer status, String filename) {
+        String format, Integer status, String filename) {
       try {
         HttpResponse response = response().withStatusCode(status);
         if (filename != null) response.withBody(BinaryBody.binary(getFileBytes(filename)));
         if (format != null) {
-          if (format == Format.JPEG) {
+          if ("JPEG".equalsIgnoreCase(format)) {
             response.withContentType(MediaType.JPEG);
           } else {
             response.withContentType(MediaType.PNG);
@@ -132,9 +130,9 @@ class PreviewApiIT {
     private void mockGetThumbnailImage(
         String fileId,
         String area,
-        Quality quality,
-        Format format,
-        Shape shape,
+        String quality,
+        String format,
+        String shape,
         Integer status,
         String filename) {
       try {
@@ -146,16 +144,16 @@ class PreviewApiIT {
                 .withPathParameter("area", area)
                 .withQueryStringParameter(param("service_type", "chats"));
         if (quality != null)
-          request.withQueryStringParameter(param("quality", quality.toString().toLowerCase()));
+          request.withQueryStringParameter(param("quality", quality.toLowerCase()));
         if (format != null)
-          request.withQueryStringParameter(param("output_format", format.toString().toLowerCase()));
+          request.withQueryStringParameter(param("output_format", format.toLowerCase()));
         if (shape != null)
-          request.withQueryStringParameter(param("shape", shape.toString().toLowerCase()));
+          request.withQueryStringParameter(param("shape", shape.toLowerCase()));
 
         HttpResponse response = response().withStatusCode(status);
         if (filename != null) response.withBody(BinaryBody.binary(getFileBytes(filename)));
         if (format != null) {
-          if (format == Format.JPEG) {
+          if ("JPEG".equalsIgnoreCase(format)) {
             response.withContentType(MediaType.JPEG);
           } else {
             response.withContentType(MediaType.PNG);
@@ -176,9 +174,11 @@ class PreviewApiIT {
                 .withPath("/preview/pdf/{fileId}/0/")
                 .withPathParameter("fileId", fileId)
                 .withQueryStringParameter(param("service_type", "chats"));
-        if (firstPage != null)
+        // The REST preview SDK only emits first_page/last_page when the value is > 0
+        // (see PreviewClient#buildPdfQueryString), so only stub them under the same condition.
+        if (firstPage != null && firstPage > 0)
           request.withQueryStringParameter(param("first_page", firstPage.toString()));
-        if (lastPage != null)
+        if (lastPage != null && lastPage > 0)
           request.withQueryStringParameter(param("last_page", lastPage.toString()));
 
         HttpResponse response = response().withStatusCode(status);
@@ -194,9 +194,9 @@ class PreviewApiIT {
     private void mockGetThumbnailPDF(
         String fileId,
         String area,
-        Quality quality,
-        Format format,
-        Shape shape,
+        String quality,
+        String format,
+        String shape,
         Integer status,
         String filename) {
       try {
@@ -208,16 +208,16 @@ class PreviewApiIT {
                 .withPathParameter("area", area)
                 .withQueryStringParameter(param("service_type", "chats"));
         if (quality != null)
-          request.withQueryStringParameter(param("quality", quality.toString().toLowerCase()));
+          request.withQueryStringParameter(param("quality", quality.toLowerCase()));
         if (format != null)
-          request.withQueryStringParameter(param("output_format", format.toString().toLowerCase()));
+          request.withQueryStringParameter(param("output_format", format.toLowerCase()));
         if (shape != null)
-          request.withQueryStringParameter(param("shape", shape.toString().toLowerCase()));
+          request.withQueryStringParameter(param("shape", shape.toLowerCase()));
 
         HttpResponse response = response().withStatusCode(status);
         if (filename != null) response.withBody(BinaryBody.binary(getFileBytes(filename)));
         if (format != null) {
-          if (format == Format.JPEG) {
+          if ("JPEG".equalsIgnoreCase(format)) {
             response.withContentType(MediaType.JPEG);
           } else {
             response.withContentType(MediaType.PNG);
@@ -286,10 +286,10 @@ class PreviewApiIT {
       previewMockServer
           .when(
               mockGetPreviewImageRequest(
-                  fileMock.getId(), "320x160", Quality.HIGH, Format.JPEG, false))
+                  fileMock.getId(), "320x160", "HIGH", "JPEG", false))
           .respond(
               mockGetPreviewImageResponse(
-                  Format.JPEG, Status.OK.getStatusCode(), expectedFile.getName()));
+                  "JPEG", Status.OK.getStatusCode(), expectedFile.getName()));
 
       MockHttpResponse response =
           dispatcher.get(
@@ -316,9 +316,9 @@ class PreviewApiIT {
       mockGetThumbnailImage(
           fileMock.getId(),
           "320x160",
-          Quality.HIGH,
-          Format.JPEG,
-          Shape.RECTANGULAR,
+          "HIGH",
+          "JPEG",
+          "RECTANGULAR",
           Status.OK.getStatusCode(),
           expectedFile.getName());
 
@@ -364,9 +364,9 @@ class PreviewApiIT {
       mockGetThumbnailPDF(
           fileMock.getId(),
           "320x160",
-          Quality.HIGH,
-          Format.JPEG,
-          Shape.RECTANGULAR,
+          "HIGH",
+          "JPEG",
+          "RECTANGULAR",
           Status.OK.getStatusCode(),
           expectedFile.getName());
 
@@ -394,7 +394,7 @@ class PreviewApiIT {
       previewMockServer
           .when(
               mockGetPreviewImageRequest(
-                  fileMock.getId(), "320x160", Quality.HIGH, Format.JPEG, false))
+                  fileMock.getId(), "320x160", "HIGH", "JPEG", false))
           .respond(mockGetPreviewImageResponse(null, 500, null));
 
       MockHttpResponse response =

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <!-- Storages -->
         <storages-sdk.version>0.0.15-SNAPSHOT</storages-sdk.version>
         <!-- Previewer -->
-        <preview-sdk.version>2.0.1-1</preview-sdk.version>
+        <preview-sdk.version>2.0.2-1</preview-sdk.version>
         <!-- Vavr: was a transitive dependency of the old carbonio-preview-sdk (not depended on by
              the new REST SDK), but io.vavr.control.Option/Try are used directly across this
              codebase, so it must now be declared explicitly. -->

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,11 @@ SPDX-License-Identifier: AGPL-3.0-only
         <!-- Storages -->
         <storages-sdk.version>0.0.15-SNAPSHOT</storages-sdk.version>
         <!-- Previewer -->
-        <preview-sdk.version>2.0.1</preview-sdk.version>
+        <preview-sdk.version>2.0.1-1</preview-sdk.version>
+        <!-- Vavr: was a transitive dependency of the old carbonio-preview-sdk (not depended on by
+             the new REST SDK), but io.vavr.control.Option/Try are used directly across this
+             codebase, so it must now be declared explicitly. -->
+        <io.vavr.version>0.11.0</io.vavr.version>
         <!-- gRPC -->
         <io.grpc.version>1.73.0</io.grpc.version>
         <!-- Jetty -->
@@ -176,8 +180,15 @@ SPDX-License-Identifier: AGPL-3.0-only
             <!-- Previewer sdk -->
             <dependency>
                 <groupId>com.zextras.carbonio.preview</groupId>
-                <artifactId>carbonio-preview-sdk</artifactId>
+                <artifactId>carbonio-preview-ce-rest-sdk</artifactId>
                 <version>${preview-sdk.version}</version>
+            </dependency>
+
+            <!-- Vavr (see io.vavr.version comment above) -->
+            <dependency>
+                <groupId>io.vavr</groupId>
+                <artifactId>vavr</artifactId>
+                <version>${io.vavr.version}</version>
             </dependency>
 
             <!-- Jetty dependencies -->


### PR DESCRIPTION
Bump the preview dependency to the released split REST SDK **carbonio-preview-ce-rest-sdk:2.0.2-1**.

The Python→Go preview rewrite replaced the single `carbonio-preview-sdk` with two edition-specific REST SDKs; `2.0.2-1` carries the enum-case lowercasing fix in the SDK `QueryBuilder` (quality/shape/output_format/service_type), so uppercase enum names sent by consumers no longer trigger the preview service's 422.

Branch = current `devel` + the SDK migration/bump. Compiled + unit-tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)