### PR TITLE
ci: pin jenkins-lib-common to v3.5.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@dt3-pipeline',
+    identifier: 'jenkins-lib-common@v3.5.1',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
Pin the `jenkins-lib-common` shared library to tag `v3.5.1` instead of tracking the `dt3-pipeline` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)