### PR TITLE
fix(auth): return 403 instead of 401 for disabled feature or inactive user

### DIFF
--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/security/AuthenticationFilter.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/security/AuthenticationFilter.java
@@ -8,6 +8,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.zextras.carbonio.chats.core.data.type.CarbonioAttribute;
 import com.zextras.carbonio.chats.core.data.type.UserType;
+import com.zextras.carbonio.chats.core.exception.ForbiddenException;
 import com.zextras.carbonio.chats.core.exception.UnauthorizedException;
 import com.zextras.carbonio.chats.core.infrastructure.authentication.AuthenticationService;
 import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfProto;
@@ -55,15 +56,16 @@ public class AuthenticationFilter implements ContainerRequestFilter {
 
               // Check if user status is ACTIVE
               if (!userMyself.getInfo().getStatus().equalsIgnoreCase("active")) {
-                throw new UnauthorizedException("User is not active");
+                throw new ForbiddenException("User is not active");
               }
 
               // Check if carbonioFeatureWscEnabled is in features list
               boolean wscEnabled =
-                  userMyself.getFeaturesList().contains(
-                      CarbonioAttribute.FEATURE_WSC_ENABLED.getValue());
+                  userMyself
+                      .getFeaturesList()
+                      .contains(CarbonioAttribute.FEATURE_WSC_ENABLED.getValue());
               if (!wscEnabled) {
-                throw new UnauthorizedException("WSC feature not enabled for user");
+                throw new ForbiddenException("WSC feature not enabled for user");
               }
               Map<String, String> capabilities = userMyself.getCapabilitiesMap();
               requestContext.setSecurityContext(

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/web/security/AuthenticationFilterTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/web/security/AuthenticationFilterTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import com.zextras.carbonio.chats.core.annotations.UnitTest;
 import com.zextras.carbonio.chats.core.data.type.UserType;
+import com.zextras.carbonio.chats.core.exception.ForbiddenException;
 import com.zextras.carbonio.chats.core.exception.UnauthorizedException;
 import com.zextras.carbonio.chats.core.infrastructure.authentication.AuthenticationService;
 import com.zextras.carbonio.user_management.sdk.grpc.UserInfoProto;
@@ -42,20 +43,25 @@ class AuthenticationFilterTest {
   }
 
   private UserMyselfProto buildUserMyselfProto(
-      String userId, String email, String fullName, String domain,
-      UserTypeProto type, String status, Map<String, String> capabilities, String... features) {
-    UserInfoProto info = UserInfoProto.newBuilder()
-        .setUserId(userId)
-        .setEmail(email)
-        .setFullName(fullName)
-        .setDomain(domain)
-        .setType(type)
-        .setStatus(status)
-        .build();
-    UserMyselfProto.Builder builder = UserMyselfProto.newBuilder()
-        .setInfo(info)
-        .setLocale("en")
-        .putAllCapabilities(capabilities);
+      String userId,
+      String email,
+      String fullName,
+      String domain,
+      UserTypeProto type,
+      String status,
+      Map<String, String> capabilities,
+      String... features) {
+    UserInfoProto info =
+        UserInfoProto.newBuilder()
+            .setUserId(userId)
+            .setEmail(email)
+            .setFullName(fullName)
+            .setDomain(domain)
+            .setType(type)
+            .setStatus(status)
+            .build();
+    UserMyselfProto.Builder builder =
+        UserMyselfProto.newBuilder().setInfo(info).setLocale("en").putAllCapabilities(capabilities);
     for (String feature : features) {
       builder.addFeatures(feature);
     }
@@ -71,9 +77,16 @@ class AuthenticationFilterTest {
     void filter_testOk() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of("carbonioFeatureWscEnabled", "TRUE");
-      UserMyselfProto userMyself = buildUserMyselfProto(
-          userId.toString(), "user@example.com", "Test User", "example.com",
-          UserTypeProto.INTERNAL, "active", capabilities, "carbonioFeatureWscEnabled");
+      UserMyselfProto userMyself =
+          buildUserMyselfProto(
+              userId.toString(),
+              "user@example.com",
+              "Test User",
+              "example.com",
+              UserTypeProto.INTERNAL,
+              "active",
+              capabilities,
+              "carbonioFeatureWscEnabled");
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())
@@ -100,9 +113,16 @@ class AuthenticationFilterTest {
     void filter_testOkForGuestUser() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of("carbonioFeatureWscEnabled", "TRUE");
-      UserMyselfProto userMyself = buildUserMyselfProto(
-          userId.toString(), "guest@example.com", "Guest User", "example.com",
-          UserTypeProto.GUEST, "active", capabilities, "carbonioFeatureWscEnabled");
+      UserMyselfProto userMyself =
+          buildUserMyselfProto(
+              userId.toString(),
+              "guest@example.com",
+              "Guest User",
+              "example.com",
+              UserTypeProto.GUEST,
+              "active",
+              capabilities,
+              "carbonioFeatureWscEnabled");
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())
@@ -146,72 +166,97 @@ class AuthenticationFilterTest {
     }
 
     @Test
-    @DisplayName("Throws an unauthorized exception if user status is not ACTIVE")
+    @DisplayName("Throws a forbidden exception if user status is not ACTIVE")
     void filter_testUserNotActive() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of("carbonioFeatureWscEnabled", "TRUE");
-      UserMyselfProto userMyself = buildUserMyselfProto(
-          userId.toString(), "user@example.com", "Test User", "example.com",
-          UserTypeProto.INTERNAL, "closed", capabilities, "carbonioFeatureWscEnabled");
+      UserMyselfProto userMyself =
+          buildUserMyselfProto(
+              userId.toString(),
+              "user@example.com",
+              "Test User",
+              "example.com",
+              UserTypeProto.INTERNAL,
+              "closed",
+              capabilities,
+              "carbonioFeatureWscEnabled");
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())
           .thenReturn(Map.of("ZM_AUTH_TOKEN", new Cookie("ZM_AUTH_TOKEN", "token")));
       when(authenticationService.getUserMyself("token")).thenReturn(Optional.of(userMyself));
 
-      assertThrows(UnauthorizedException.class, () -> authenticationFilter.filter(requestContext));
+      assertThrows(ForbiddenException.class, () -> authenticationFilter.filter(requestContext));
     }
 
     @Test
-    @DisplayName("Throws an unauthorized exception if WSC feature is disabled for internal user")
+    @DisplayName("Throws a forbidden exception if WSC feature is disabled for internal user")
     void filter_testWscFeatureDisabledForInternalUser() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of("carbonioFeatureWscEnabled", "FALSE");
-      UserMyselfProto userMyself = buildUserMyselfProto(
-          userId.toString(), "user@example.com", "Test User", "example.com",
-          UserTypeProto.INTERNAL, "active", capabilities);
+      UserMyselfProto userMyself =
+          buildUserMyselfProto(
+              userId.toString(),
+              "user@example.com",
+              "Test User",
+              "example.com",
+              UserTypeProto.INTERNAL,
+              "active",
+              capabilities);
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())
           .thenReturn(Map.of("ZM_AUTH_TOKEN", new Cookie("ZM_AUTH_TOKEN", "token")));
       when(authenticationService.getUserMyself("token")).thenReturn(Optional.of(userMyself));
 
-      assertThrows(UnauthorizedException.class, () -> authenticationFilter.filter(requestContext));
+      assertThrows(ForbiddenException.class, () -> authenticationFilter.filter(requestContext));
     }
 
     @Test
-    @DisplayName("Throws an unauthorized exception if WSC feature is disabled for guest user")
+    @DisplayName("Throws a forbidden exception if WSC feature is disabled for guest user")
     void filter_testWscFeatureDisabledForGuestUser() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of("carbonioFeatureWscEnabled", "FALSE");
-      UserMyselfProto userMyself = buildUserMyselfProto(
-          userId.toString(), "user@example.com", "Test User", "example.com",
-          UserTypeProto.GUEST, "active", capabilities);
+      UserMyselfProto userMyself =
+          buildUserMyselfProto(
+              userId.toString(),
+              "user@example.com",
+              "Test User",
+              "example.com",
+              UserTypeProto.GUEST,
+              "active",
+              capabilities);
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())
           .thenReturn(Map.of("ZM_AUTH_TOKEN", new Cookie("ZM_AUTH_TOKEN", "token")));
       when(authenticationService.getUserMyself("token")).thenReturn(Optional.of(userMyself));
 
-      assertThrows(UnauthorizedException.class, () -> authenticationFilter.filter(requestContext));
+      assertThrows(ForbiddenException.class, () -> authenticationFilter.filter(requestContext));
     }
 
     @Test
     @DisplayName(
-        "Throws an unauthorized exception if WSC feature attribute is missing for internal user")
+        "Throws a forbidden exception if WSC feature attribute is missing for internal user")
     void filter_testWscFeatureMissingForInternalUser() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of();
-      UserMyselfProto userMyself = buildUserMyselfProto(
-          userId.toString(), "user@example.com", "Test User", "example.com",
-          UserTypeProto.INTERNAL, "active", capabilities);
+      UserMyselfProto userMyself =
+          buildUserMyselfProto(
+              userId.toString(),
+              "user@example.com",
+              "Test User",
+              "example.com",
+              UserTypeProto.INTERNAL,
+              "active",
+              capabilities);
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())
           .thenReturn(Map.of("ZM_AUTH_TOKEN", new Cookie("ZM_AUTH_TOKEN", "token")));
       when(authenticationService.getUserMyself("token")).thenReturn(Optional.of(userMyself));
 
-      assertThrows(UnauthorizedException.class, () -> authenticationFilter.filter(requestContext));
+      assertThrows(ForbiddenException.class, () -> authenticationFilter.filter(requestContext));
     }
   }
 }

--- a/carbonio-ws-collaboration-openapi/src/main/resources/api.yaml
+++ b/carbonio-ws-collaboration-openapi/src/main/resources/api.yaml
@@ -379,6 +379,8 @@ paths:
           $ref: "#/components/responses/200GetCapabilities"
         401:
           $ref: "#/components/responses/401UnauthorizedResponse"
+        403:
+          $ref: "#/components/responses/403ForbiddenResponse"
   /users/{userId}:
     get:
       tags:
@@ -746,6 +748,8 @@ paths:
           $ref: '#/components/responses/200GetTokenResponse'
         401:
           $ref: '#/components/responses/401UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/403ForbiddenResponse'
         404:
           $ref: '#/components/responses/404NotFoundResponse'
   /meetings:


### PR DESCRIPTION
AuthenticationFilter threw UnauthorizedException (401) when a user's account was inactive or the WSC feature was disabled for them. Both conditions describe an authenticated-but-not-entitled request, not an authentication failure, so they now throw ForbiddenException (403) with an explicit message instead of a generic unauthorized error.

Documented the 403 response on the two affected endpoints (GetCapabilities, GetToken) in api.yaml, alongside the existing 401.

ref: CO-3482