### PR TITLE
feat: migrate user-management client to the REST SDK

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -1,7 +1,7 @@
 AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
 
   Carbonio Systemd Notify (com.zextras.carbonio:carbonio-systemd-notify:1.0.1)
-  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.0.3-dev.21.79fc3fa2)
+  Carbonio User Management - REST SDK (com.zextras.carbonio.user-management:carbonio-user-management-rest-sdk:1.3.0-1)
   filestore-sdk-common (com.zextras:filestore-sdk-common:0.0.15-20251106.164324-4)
   storages-ce-sdk (com.zextras:storages-ce-sdk:0.0.15-20251106.164324-4)
 
@@ -78,34 +78,22 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   EE10 :: Websocket :: Jakarta Common (org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jakarta-common:12.0.19)
   EE10 :: Websocket :: Jakarta Server (org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jakarta-server:12.0.19)
   EE10 :: Websocket :: Servlet (org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-servlet:12.0.19)
-  error-prone annotations (com.google.errorprone:error_prone_annotations:2.30.0)
+  error-prone annotations (com.google.errorprone:error_prone_annotations:2.21.1)
   error-prone annotations (com.google.errorprone:error_prone_annotations:2.7.1)
   FindBugs-jsr305 (com.google.code.findbugs:jsr305:3.0.2)
   flyway-core (org.flywaydb:flyway-core:10.19.0)
   flyway-database-postgresql (org.flywaydb:flyway-database-postgresql:10.19.0)
-  Google Android Annotations Library (com.google.android:annotations:4.1.1.4)
   Google Guice - Core Library (com.google.inject:guice:7.0.0)
-  Gson (com.google.code.gson:gson:2.11.0)
+  Gson (com.google.code.gson:gson:2.8.5)
   Guava InternalFutureFailureAccess and InternalFutures (com.google.guava:failureaccess:1.0.1)
-  Guava InternalFutureFailureAccess and InternalFutures (com.google.guava:failureaccess:1.0.2)
   Guava ListenableFuture only (com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava)
   Guava: Google Core Libraries for Java (com.google.guava:guava:31.0.1-jre)
   Guava: Google Core Libraries for Java (com.google.guava:guava:31.1-jre)
-  Guava: Google Core Libraries for Java (com.google.guava:guava:33.3.1-android)
   Hibernate Validator Engine (org.hibernate.validator:hibernate-validator:8.0.3.Final)
   Hibernate Validator Portable Extension (org.hibernate.validator:hibernate-validator-cdi:8.0.3.Final)
   HikariCP (com.zaxxer:HikariCP:6.0.0)
   IntelliJ IDEA Annotations (org.jetbrains:annotations:13.0)
-  io.grpc:grpc-api (io.grpc:grpc-api:1.73.0)
-  io.grpc:grpc-context (io.grpc:grpc-context:1.73.0)
-  io.grpc:grpc-core (io.grpc:grpc-core:1.73.0)
-  io.grpc:grpc-netty-shaded (io.grpc:grpc-netty-shaded:1.73.0)
-  io.grpc:grpc-protobuf (io.grpc:grpc-protobuf:1.79.0)
-  io.grpc:grpc-protobuf-lite (io.grpc:grpc-protobuf-lite:1.79.0)
-  io.grpc:grpc-stub (io.grpc:grpc-stub:1.79.0)
-  io.grpc:grpc-util (io.grpc:grpc-util:1.73.0)
   J2ObjC Annotations (com.google.j2objc:j2objc-annotations:1.3)
-  J2ObjC Annotations (com.google.j2objc:j2objc-annotations:3.0.0)
   Jackson datatype: Guava (com.fasterxml.jackson.datatype:jackson-datatype-guava:2.12.0)
   Jackson datatype: jdk8 (com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.0)
   Jackson datatype: JSR310 (com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.0)
@@ -129,8 +117,6 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   JsonNullable Jackson module (org.openapitools:jackson-databind-nullable:0.2.6)
   okhttp (com.squareup.okhttp3:okhttp:4.9.0)
   Okio (com.squareup.okio:okio:2.8.0)
-  perfmark:perfmark-api (io.perfmark:perfmark-api:0.27.0)
-  proto-google-common-protos (com.google.api.grpc:proto-google-common-protos:2.63.2)
   RabbitMQ Java Client (com.rabbitmq:amqp-client:5.22.0)
   Reflections (org.reflections:reflections:0.10.2)
   RESTEasy Client (org.jboss.resteasy:resteasy-client:7.0.0.Alpha2)
@@ -163,7 +149,6 @@ BSD-3-Clause (https://spdx.org/licenses/BSD-3-Clause.html) applies to:
   asm (org.ow2.asm:asm:9.7.1)
   asm-commons (org.ow2.asm:asm-commons:9.7.1)
   asm-tree (org.ow2.asm:asm-tree:9.7.1)
-  Protocol Buffers [Core] (com.google.protobuf:protobuf-java:4.33.2)
 
 CDDL + GPLv2 with classpath exception (https://spdx.org/licenses/CDDL + GPLv2 with classpath exception.html) applies to:
 
@@ -293,10 +278,6 @@ MIT (https://spdx.org/licenses/MIT.html) applies to:
   Checker Qual (org.checkerframework:checker-qual:3.42.0)
   semver4j (com.vdurmont:semver4j:3.1.0)
   SLF4J API Module (org.slf4j:slf4j-api:2.0.16)
-
-MIT license (https://spdx.org/licenses/MIT license.html) applies to:
-
-  Animal Sniffer Annotations (org.codehaus.mojo:animal-sniffer-annotations:1.24)
 
 MIT-0 (https://spdx.org/licenses/MIT-0.html) applies to:
 

--- a/carbonio-ws-collaboration-core/pom.xml
+++ b/carbonio-ws-collaboration-core/pom.xml
@@ -27,16 +27,10 @@ SPDX-License-Identifier: AGPL-3.0-only
             <artifactId>carbonio-ws-collaboration-ce-openapi</artifactId>
         </dependency>
 
-        <!-- Carbonio User Management gRPC SDK -->
+        <!-- Carbonio User Management REST SDK -->
         <dependency>
             <groupId>com.zextras.carbonio.user-management</groupId>
-            <artifactId>carbonio-user-management-grpc-sdk</artifactId>
-        </dependency>
-
-        <!-- gRPC dependencies -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty-shaded</artifactId>
+            <artifactId>carbonio-user-management-rest-sdk</artifactId>
         </dependency>
 
         <!-- Storages sdk -->

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/config/module/CoreModule.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/config/module/CoreModule.java
@@ -138,6 +138,7 @@ import io.ebean.annotation.Platform;
 import io.ebean.config.DatabaseConfig;
 import java.io.IOException;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Properties;
@@ -148,6 +149,12 @@ import org.flywaydb.core.api.migration.JavaMigration;
 public class CoreModule extends AbstractModule {
 
   private static final String URL_PATTERN = "http://%s:%s";
+
+  // 5s connect + read timeout: this codebase's existing convention for a shared client calling
+  // another Carbonio service over the mesh (see HttpClientProvider.TIMEOUT_MILLIS, also 5000ms).
+  // Without it, the generated ApiClient defaults to null timeouts, i.e. no request timeout at
+  // the JDK HttpClient level and an OS-default (~2 min) TCP connect timeout.
+  private static final Duration USER_MANAGEMENT_TIMEOUT = Duration.ofMillis(5000);
 
   @Override
   protected void configure() {
@@ -288,6 +295,10 @@ public class CoreModule extends AbstractModule {
     ApiClient apiClient =
         new ApiClient(
             httpClientBuilder, ApiClient.createDefaultObjectMapper(), userManagementBaseUrl);
+    // Must be set before constructing UserResourceApi: its constructor snapshots the ApiClient's
+    // timeouts into final fields, so setting them afterwards would be a silent no-op.
+    apiClient.setConnectTimeout(USER_MANAGEMENT_TIMEOUT);
+    apiClient.setReadTimeout(USER_MANAGEMENT_TIMEOUT);
     return new UserResourceApi(apiClient);
   }
 

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/config/module/CoreModule.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/config/module/CoreModule.java
@@ -129,15 +129,13 @@ import com.zextras.carbonio.chats.core.web.socket.VideoServerEventListener;
 import com.zextras.carbonio.chats.core.web.socket.versioning.WebsocketVersionMigrator;
 import com.zextras.carbonio.chats.core.web.utility.HttpClient;
 import com.zextras.carbonio.preview.sdk.PreviewClient;
-import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc;
-import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc.UserManagementServiceBlockingStub;
+import com.zextras.carbonio.user_management.sdk.rest.ApiClient;
+import com.zextras.carbonio.user_management.sdk.rest.api.UserResourceApi;
 import com.zextras.storages.api.StoragesClient;
 import io.ebean.Database;
 import io.ebean.DatabaseFactory;
 import io.ebean.annotation.Platform;
 import io.ebean.config.DatabaseConfig;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.ZoneId;
@@ -272,18 +270,25 @@ public class CoreModule extends AbstractModule {
 
   @Singleton
   @Provides
-  @Named("userManagementChannel")
-  private ManagedChannel getUserManagementChannel(AppConfig appConfig) {
-    String host = appConfig.get(String.class, ConfigName.USER_MANAGEMENT_HOST).orElseThrow();
-    int port = appConfig.get(Integer.class, ConfigName.USER_MANAGEMENT_PORT).orElseThrow();
-    return ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
+  @Named("userManagementBaseUrl")
+  private String getUserManagementBaseUrl(AppConfig appConfig) {
+    return String.format(
+        URL_PATTERN,
+        appConfig.get(String.class, ConfigName.USER_MANAGEMENT_HOST).orElseThrow(),
+        appConfig.get(String.class, ConfigName.USER_MANAGEMENT_PORT).orElseThrow());
   }
 
   @Singleton
   @Provides
-  private UserManagementServiceBlockingStub getUserManagementStub(
-      @Named("userManagementChannel") ManagedChannel userManagementChannel) {
-    return UserManagementServiceGrpc.newBlockingStub(userManagementChannel);
+  private UserResourceApi getUserResourceApi(
+      @Named("userManagementBaseUrl") String userManagementBaseUrl) {
+    // Pin HTTP/1.1: the User Management service does not support h2c cleartext upgrade.
+    java.net.http.HttpClient.Builder httpClientBuilder =
+        java.net.http.HttpClient.newBuilder().version(java.net.http.HttpClient.Version.HTTP_1_1);
+    ApiClient apiClient =
+        new ApiClient(
+            httpClientBuilder, ApiClient.createDefaultObjectMapper(), userManagementBaseUrl);
+    return new UserResourceApi(apiClient);
   }
 
   @Singleton

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/data/type/UserType.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/data/type/UserType.java
@@ -4,17 +4,16 @@
 
 package com.zextras.carbonio.chats.core.data.type;
 
-import com.zextras.carbonio.user_management.sdk.grpc.UserTypeProto;
-
 public enum UserType {
   INTERNAL,
   GUEST;
 
-  public static UserType from(UserTypeProto umType) {
-    return switch (umType) {
-      case GUEST -> GUEST;
-      case INTERNAL -> INTERNAL;
-      default -> INTERNAL;
-    };
+  /**
+   * Maps the plain-string {@code type} field returned by the User Management REST SDK (e.g.
+   * {@code UserInfoDto.getType()}) to a {@link UserType}. Unknown/unexpected values default to
+   * {@link #INTERNAL}, matching the previous gRPC enum mapping's default branch.
+   */
+  public static UserType from(String umType) {
+    return "GUEST".equalsIgnoreCase(umType) ? GUEST : INTERNAL;
   }
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/authentication/AuthenticationService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/authentication/AuthenticationService.java
@@ -5,7 +5,7 @@
 package com.zextras.carbonio.chats.core.infrastructure.authentication;
 
 import com.zextras.carbonio.chats.core.infrastructure.HealthIndicator;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfProto;
+import com.zextras.carbonio.user_management.sdk.rest.model.MyselfDto;
 
 import java.util.Optional;
 
@@ -23,7 +23,7 @@ public interface AuthenticationService extends HealthIndicator {
    * Validates the user's credentials
    *
    * @param authToken the token needed to be authenticated
-   * @return the {@link UserMyselfProto} if the token is valid
+   * @return the {@link MyselfDto} if the token is valid
    */
-  Optional<UserMyselfProto> getUserMyself(String authToken);
+  Optional<MyselfDto> getUserMyself(String authToken);
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationService.java
@@ -7,13 +7,13 @@ package com.zextras.carbonio.chats.core.infrastructure.authentication.impl;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
+import com.zextras.carbonio.chats.core.exception.AuthenticationException;
 import com.zextras.carbonio.chats.core.infrastructure.authentication.AuthenticationService;
 import com.zextras.carbonio.chats.core.logging.ChatsLogger;
 import com.zextras.carbonio.chats.core.web.utility.HttpClient;
 import com.zextras.carbonio.user_management.sdk.rest.ApiException;
 import com.zextras.carbonio.user_management.sdk.rest.api.UserResourceApi;
 import com.zextras.carbonio.user_management.sdk.rest.model.MyselfDto;
-import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -50,9 +50,11 @@ public class UserManagementAuthenticationService implements AuthenticationServic
       if (e.getCode() == HTTP_UNAUTHORIZED) {
         return Optional.empty();
       }
-      ChatsLogger.warn(
-          "Credential validation failed for token " + authToken + "\n " + e.getMessage());
-      return Optional.empty();
+      // Anything other than a 401 (including code 0 from a network failure/timeout, and 4xx/5xx)
+      // is not a real "bad credentials" answer: it means User Management itself could not be
+      // reached or misbehaved, so it must surface as a dependency failure, not a silent logout.
+      ChatsLogger.warn("Credential validation failed for the provided token\n " + e.getMessage());
+      throw new AuthenticationException(e);
     }
   }
 
@@ -68,10 +70,14 @@ public class UserManagementAuthenticationService implements AuthenticationServic
     try {
       return userResourceApi.internalUsersMyselfGet(authToken);
     } catch (ApiException e) {
-      if (e.getCode() != HTTP_UNAUTHORIZED) {
-        ChatsLogger.warn("Authentication failed for token " + authToken + "\n " + e.getMessage());
+      if (e.getCode() == HTTP_UNAUTHORIZED) {
+        return null;
       }
-      return null;
+      // Same reasoning as validateCredentials: only a genuine 401 means "not authenticated".
+      // Everything else is a dependency failure and must not be swallowed into an anonymous/401
+      // response by the caller.
+      ChatsLogger.warn("Authentication failed for the provided token\n " + e.getMessage());
+      throw new AuthenticationException(e);
     }
   }
 
@@ -80,7 +86,12 @@ public class UserManagementAuthenticationService implements AuthenticationServic
     try (CloseableHttpResponse response =
         httpClient.sendGet(userManagementBaseUrl + HEALTH_LIVE_PATH, Map.of())) {
       return response.getStatusLine().getStatusCode() == 200;
-    } catch (IOException e) {
+    } catch (Exception e) {
+      // HttpClient wraps connection failures (refused, DNS, timeout) in an unchecked
+      // ChatsHttpException instead of the checked IOException declared on sendGet(), so this must
+      // catch Exception, not IOException, or a dead User Management takes the whole healthcheck
+      // down with it instead of being reported as an unhealthy dependency.
+      ChatsLogger.warn("Can't communicate with User Management due to: " + e);
       return false;
     }
   }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationService.java
@@ -44,7 +44,7 @@ public class UserManagementAuthenticationService implements AuthenticationServic
       return Optional.empty();
     }
     try {
-      MyselfDto myself = userResourceApi.internalUsersMyselfGet(authToken);
+      MyselfDto myself = userResourceApi.internalUsersMyselfGet(null, authToken);
       return Optional.ofNullable(myself.getInfo().getUserId());
     } catch (ApiException e) {
       if (e.getCode() == HTTP_UNAUTHORIZED) {
@@ -68,7 +68,7 @@ public class UserManagementAuthenticationService implements AuthenticationServic
 
   private MyselfDto fetchUserMyself(String authToken) {
     try {
-      return userResourceApi.internalUsersMyselfGet(authToken);
+      return userResourceApi.internalUsersMyselfGet(null, authToken);
     } catch (ApiException e) {
       if (e.getCode() == HTTP_UNAUTHORIZED) {
         return null;

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationService.java
@@ -9,28 +9,33 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.zextras.carbonio.chats.core.infrastructure.authentication.AuthenticationService;
 import com.zextras.carbonio.chats.core.logging.ChatsLogger;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUserMyselfRequest;
-import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc.UserManagementServiceBlockingStub;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfProto;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfResponse;
-import io.grpc.ConnectivityState;
-import io.grpc.ManagedChannel;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
+import com.zextras.carbonio.chats.core.web.utility.HttpClient;
+import com.zextras.carbonio.user_management.sdk.rest.ApiException;
+import com.zextras.carbonio.user_management.sdk.rest.api.UserResourceApi;
+import com.zextras.carbonio.user_management.sdk.rest.model.MyselfDto;
+import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
+import org.apache.http.client.methods.CloseableHttpResponse;
 
 @Singleton
 public class UserManagementAuthenticationService implements AuthenticationService {
 
-  private final UserManagementServiceBlockingStub userManagementStub;
-  private final ManagedChannel userManagementChannel;
+  private static final String HEALTH_LIVE_PATH = "/q/health/live";
+  private static final int HTTP_UNAUTHORIZED = 401;
+
+  private final UserResourceApi userResourceApi;
+  private final HttpClient httpClient;
+  private final String userManagementBaseUrl;
 
   @Inject
   public UserManagementAuthenticationService(
-      UserManagementServiceBlockingStub userManagementStub,
-      @Named("userManagementChannel") ManagedChannel userManagementChannel) {
-    this.userManagementStub = userManagementStub;
-    this.userManagementChannel = userManagementChannel;
+      UserResourceApi userResourceApi,
+      HttpClient httpClient,
+      @Named("userManagementBaseUrl") String userManagementBaseUrl) {
+    this.userResourceApi = userResourceApi;
+    this.httpClient = httpClient;
+    this.userManagementBaseUrl = userManagementBaseUrl;
   }
 
   @Override
@@ -39,12 +44,10 @@ public class UserManagementAuthenticationService implements AuthenticationServic
       return Optional.empty();
     }
     try {
-      GetUserMyselfRequest request =
-          GetUserMyselfRequest.newBuilder().setToken(authToken).build();
-      UserMyselfResponse response = userManagementStub.getUserMyself(request);
-      return Optional.ofNullable(response.getUser().getInfo().getUserId());
-    } catch (StatusRuntimeException e) {
-      if (e.getStatus().getCode() == Status.Code.UNAUTHENTICATED) {
+      MyselfDto myself = userResourceApi.internalUsersMyselfGet(cookieHeader(authToken));
+      return Optional.ofNullable(myself.getInfo().getUserId());
+    } catch (ApiException e) {
+      if (e.getCode() == HTTP_UNAUTHORIZED) {
         return Optional.empty();
       }
       ChatsLogger.warn(
@@ -54,31 +57,35 @@ public class UserManagementAuthenticationService implements AuthenticationServic
   }
 
   @Override
-  public Optional<UserMyselfProto> getUserMyself(String authToken) {
+  public Optional<MyselfDto> getUserMyself(String authToken) {
     if (authToken == null) {
       return Optional.empty();
     }
     return Optional.ofNullable(fetchUserMyself(authToken));
   }
 
-  private UserMyselfProto fetchUserMyself(String authToken) {
+  private MyselfDto fetchUserMyself(String authToken) {
     try {
-      GetUserMyselfRequest request =
-          GetUserMyselfRequest.newBuilder().setToken(authToken).build();
-      UserMyselfResponse response = userManagementStub.getUserMyself(request);
-      return response.getUser();
-    } catch (StatusRuntimeException e) {
-      if (e.getStatus().getCode() != Status.Code.UNAUTHENTICATED) {
-        ChatsLogger.warn(
-            "Authentication failed for token " + authToken + "\n " + e.getMessage());
+      return userResourceApi.internalUsersMyselfGet(cookieHeader(authToken));
+    } catch (ApiException e) {
+      if (e.getCode() != HTTP_UNAUTHORIZED) {
+        ChatsLogger.warn("Authentication failed for token " + authToken + "\n " + e.getMessage());
       }
       return null;
     }
   }
 
+  private Map<String, String> cookieHeader(String authToken) {
+    return Map.of("Cookie", "ZM_AUTH_TOKEN=" + authToken);
+  }
+
   @Override
   public boolean isAlive() {
-    ConnectivityState state = userManagementChannel.getState(true);
-    return state == ConnectivityState.READY || state == ConnectivityState.IDLE;
+    try (CloseableHttpResponse response =
+        httpClient.sendGet(userManagementBaseUrl + HEALTH_LIVE_PATH, Map.of())) {
+      return response.getStatusLine().getStatusCode() == 200;
+    } catch (IOException e) {
+      return false;
+    }
   }
 }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationService.java
@@ -44,7 +44,7 @@ public class UserManagementAuthenticationService implements AuthenticationServic
       return Optional.empty();
     }
     try {
-      MyselfDto myself = userResourceApi.internalUsersMyselfGet(cookieHeader(authToken));
+      MyselfDto myself = userResourceApi.internalUsersMyselfGet(authToken);
       return Optional.ofNullable(myself.getInfo().getUserId());
     } catch (ApiException e) {
       if (e.getCode() == HTTP_UNAUTHORIZED) {
@@ -66,17 +66,13 @@ public class UserManagementAuthenticationService implements AuthenticationServic
 
   private MyselfDto fetchUserMyself(String authToken) {
     try {
-      return userResourceApi.internalUsersMyselfGet(cookieHeader(authToken));
+      return userResourceApi.internalUsersMyselfGet(authToken);
     } catch (ApiException e) {
       if (e.getCode() != HTTP_UNAUTHORIZED) {
         ChatsLogger.warn("Authentication failed for token " + authToken + "\n " + e.getMessage());
       }
       return null;
     }
-  }
-
-  private Map<String, String> cookieHeader(String authToken) {
-    return Map.of("Cookie", "ZM_AUTH_TOKEN=" + authToken);
   }
 
   @Override

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingService.java
@@ -13,46 +13,45 @@ import com.zextras.carbonio.chats.core.exception.ForbiddenException;
 import com.zextras.carbonio.chats.core.exception.ProfilingException;
 import com.zextras.carbonio.chats.core.infrastructure.profiling.ProfilingService;
 import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUserByIdRequest;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUsersRequest;
-import com.zextras.carbonio.user_management.sdk.grpc.UserInfoProto;
-import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc.UserManagementServiceBlockingStub;
-import io.grpc.ConnectivityState;
-import io.grpc.ManagedChannel;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
+import com.zextras.carbonio.chats.core.web.utility.HttpClient;
+import com.zextras.carbonio.user_management.sdk.rest.ApiException;
+import com.zextras.carbonio.user_management.sdk.rest.api.UserResourceApi;
+import com.zextras.carbonio.user_management.sdk.rest.model.UserInfoDto;
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.http.client.methods.CloseableHttpResponse;
 
 @Singleton
 public class UserManagementProfilingService implements ProfilingService {
 
-  private final UserManagementServiceBlockingStub userManagementStub;
-  private final ManagedChannel userManagementChannel;
+  private static final String HEALTH_LIVE_PATH = "/q/health/live";
+  private static final int HTTP_NOT_FOUND = 404;
+
+  private final UserResourceApi userResourceApi;
+  private final HttpClient httpClient;
+  private final String userManagementBaseUrl;
 
   @Inject
   public UserManagementProfilingService(
-      UserManagementServiceBlockingStub userManagementStub,
-      @Named("userManagementChannel") ManagedChannel userManagementChannel) {
-    this.userManagementStub = userManagementStub;
-    this.userManagementChannel = userManagementChannel;
+      UserResourceApi userResourceApi,
+      HttpClient httpClient,
+      @Named("userManagementBaseUrl") String userManagementBaseUrl) {
+    this.userResourceApi = userResourceApi;
+    this.httpClient = httpClient;
+    this.userManagementBaseUrl = userManagementBaseUrl;
   }
 
   @Override
   public Optional<UserProfile> getById(UserPrincipal principal, UUID userId) {
     principal.getAuthToken().orElseThrow(ForbiddenException::new);
     try {
-      UserInfoProto userInfo =
-          userManagementStub
-              .getUserById(
-                  GetUserByIdRequest.newBuilder()
-                      .setUserId(userId.toString())
-                      .build())
-              .getUser();
+      UserInfoDto userInfo = userResourceApi.internalUsersIdUserIdGet(userId.toString());
       return Optional.of(mapToUserProfile(userInfo));
-    } catch (StatusRuntimeException e) {
-      if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
+    } catch (ApiException e) {
+      if (e.getCode() == HTTP_NOT_FOUND) {
         return Optional.empty();
       }
       throw new ProfilingException(e);
@@ -63,25 +62,25 @@ public class UserManagementProfilingService implements ProfilingService {
   public List<UserProfile> getByIds(UserPrincipal principal, List<String> userIds) {
     principal.getAuthToken().orElseThrow(ForbiddenException::new);
     try {
-      return userManagementStub
-          .getUsers(
-              GetUsersRequest.newBuilder().addAllUserIds(userIds).build())
-          .getUsersList()
-          .stream()
+      return userResourceApi.internalUsersPost(userIds).stream()
           .map(this::mapToUserProfile)
           .toList();
-    } catch (StatusRuntimeException e) {
+    } catch (ApiException e) {
       throw new ProfilingException(e);
     }
   }
 
   @Override
   public boolean isAlive() {
-    ConnectivityState state = userManagementChannel.getState(true);
-    return state == ConnectivityState.READY || state == ConnectivityState.IDLE;
+    try (CloseableHttpResponse response =
+        httpClient.sendGet(userManagementBaseUrl + HEALTH_LIVE_PATH, Map.of())) {
+      return response.getStatusLine().getStatusCode() == 200;
+    } catch (IOException e) {
+      return false;
+    }
   }
 
-  private UserProfile mapToUserProfile(UserInfoProto userInfo) {
+  private UserProfile mapToUserProfile(UserInfoDto userInfo) {
     return UserProfile.create(userInfo.getUserId())
         .name(userInfo.getFullName())
         .email(userInfo.getEmail())

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingService.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingService.java
@@ -12,12 +12,12 @@ import com.zextras.carbonio.chats.core.data.type.UserType;
 import com.zextras.carbonio.chats.core.exception.ForbiddenException;
 import com.zextras.carbonio.chats.core.exception.ProfilingException;
 import com.zextras.carbonio.chats.core.infrastructure.profiling.ProfilingService;
+import com.zextras.carbonio.chats.core.logging.ChatsLogger;
 import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
 import com.zextras.carbonio.chats.core.web.utility.HttpClient;
 import com.zextras.carbonio.user_management.sdk.rest.ApiException;
 import com.zextras.carbonio.user_management.sdk.rest.api.UserResourceApi;
 import com.zextras.carbonio.user_management.sdk.rest.model.UserInfoDto;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -75,7 +75,12 @@ public class UserManagementProfilingService implements ProfilingService {
     try (CloseableHttpResponse response =
         httpClient.sendGet(userManagementBaseUrl + HEALTH_LIVE_PATH, Map.of())) {
       return response.getStatusLine().getStatusCode() == 200;
-    } catch (IOException e) {
+    } catch (Exception e) {
+      // HttpClient wraps connection failures (refused, DNS, timeout) in an unchecked
+      // ChatsHttpException instead of the checked IOException declared on sendGet(), so this must
+      // catch Exception, not IOException, or a dead User Management takes the whole healthcheck
+      // down with it instead of being reported as an unhealthy dependency.
+      ChatsLogger.warn("Can't communicate with User Management due to: " + e);
       return false;
     }
   }

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/HealthcheckServiceImpl.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/service/impl/HealthcheckServiceImpl.java
@@ -52,34 +52,49 @@ public class HealthcheckServiceImpl implements HealthcheckService {
 
   @Override
   public HealthStatusTypeDto getServiceStatus() {
-    return checkServiceStatus();
+    return checkServiceStatus(snapshotDependencies());
   }
 
   @Override
   public HealthStatusDto getServiceHealth() {
+    List<DependencySnapshot> snapshot = snapshotDependencies();
     return HealthStatusDto.create()
         .isLive(true)
-        .status(checkServiceStatus())
+        .status(checkServiceStatus(snapshot))
         .dependencies(
-            dependencies.stream()
+            snapshot.stream()
                 .map(
-                    dependency ->
+                    entry ->
                         DependencyHealthDto.create()
-                            .name(dependency.getDependencyHealthType())
-                            .isHealthy(dependency.isAlive()))
+                            .name(entry.dependency().getDependencyHealthType())
+                            .isHealthy(entry.alive()))
                 .toList());
   }
 
-  private HealthStatusTypeDto checkServiceStatus() {
-    if (dependencies.stream()
-        .anyMatch(dependency -> dependency.getType().isRequired() && !dependency.isAlive())) {
+  /**
+   * Calls {@code isAlive()} on every dependency exactly once and snapshots the result. Each
+   * dependency is a real network round trip (e.g. to User Management), so without this the
+   * required/optional passes below and the DTO mapping would each re-check every dependency,
+   * turning a single {@code /health} request into several redundant calls per dependency.
+   */
+  private List<DependencySnapshot> snapshotDependencies() {
+    return dependencies.stream()
+        .map(dependency -> new DependencySnapshot(dependency, dependency.isAlive()))
+        .toList();
+  }
+
+  private HealthStatusTypeDto checkServiceStatus(List<DependencySnapshot> snapshot) {
+    if (snapshot.stream()
+        .anyMatch(entry -> entry.dependency().getType().isRequired() && !entry.alive())) {
       return HealthStatusTypeDto.ERROR;
-    } else if (dependencies.stream()
-        .anyMatch(dependency -> !dependency.getType().isRequired() && !dependency.isAlive())) {
+    } else if (snapshot.stream()
+        .anyMatch(entry -> !entry.dependency().getType().isRequired() && !entry.alive())) {
       return HealthStatusTypeDto.WARN;
     }
     return HealthStatusTypeDto.OK;
   }
+
+  private record DependencySnapshot(HealthDependency dependency, boolean alive) {}
 
   private static class HealthDependency {
 

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/security/AuthenticationFilter.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/security/AuthenticationFilter.java
@@ -10,7 +10,7 @@ import com.zextras.carbonio.chats.core.data.type.CarbonioAttribute;
 import com.zextras.carbonio.chats.core.data.type.UserType;
 import com.zextras.carbonio.chats.core.exception.UnauthorizedException;
 import com.zextras.carbonio.chats.core.infrastructure.authentication.AuthenticationService;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfProto;
+import com.zextras.carbonio.user_management.sdk.rest.model.MyselfDto;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.PreMatching;
@@ -48,7 +48,7 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         .ifPresentOrElse(
             token -> {
               // If the user token is invalid, we won't authenticate him/her as anonymous
-              UserMyselfProto userMyself =
+              MyselfDto userMyself =
                   authenticationService
                       .getUserMyself(token)
                       .orElseThrow(UnauthorizedException::new);
@@ -60,12 +60,12 @@ public class AuthenticationFilter implements ContainerRequestFilter {
 
               // Check if carbonioFeatureWscEnabled is in features list
               boolean wscEnabled =
-                  userMyself.getFeaturesList().contains(
+                  userMyself.getFeatures().contains(
                       CarbonioAttribute.FEATURE_WSC_ENABLED.getValue());
               if (!wscEnabled) {
                 throw new UnauthorizedException("WSC feature not enabled for user");
               }
-              Map<String, String> capabilities = userMyself.getCapabilitiesMap();
+              Map<String, String> capabilities = userMyself.getCapabilities();
               requestContext.setSecurityContext(
                   SecurityContextImpl.create(
                       UserPrincipal.create(userMyself.getInfo().getUserId())

--- a/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/security/EventsWebSocketAuthenticationFilter.java
+++ b/carbonio-ws-collaboration-core/src/main/java/com/zextras/carbonio/chats/core/web/security/EventsWebSocketAuthenticationFilter.java
@@ -7,7 +7,7 @@ package com.zextras.carbonio.chats.core.web.security;
 import com.zextras.carbonio.chats.core.data.type.CarbonioAttribute;
 import com.zextras.carbonio.chats.core.infrastructure.authentication.AuthenticationService;
 import com.zextras.carbonio.chats.core.logging.ChatsLogger;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfProto;
+import com.zextras.carbonio.user_management.sdk.rest.model.MyselfDto;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -53,7 +53,7 @@ public class EventsWebSocketAuthenticationFilter implements Filter {
       return;
     }
 
-    Optional<UserMyselfProto> userMyselfOpt = authenticationService.getUserMyself(authToken.get());
+    Optional<MyselfDto> userMyselfOpt = authenticationService.getUserMyself(authToken.get());
 
     if (userMyselfOpt.isEmpty()) {
       ChatsLogger.warn("Websocket authentication failed for token " + authToken.get());
@@ -61,7 +61,7 @@ public class EventsWebSocketAuthenticationFilter implements Filter {
       return;
     }
 
-    UserMyselfProto userMyself = userMyselfOpt.get();
+    MyselfDto userMyself = userMyselfOpt.get();
 
     // Check if user status is ACTIVE
     if (!userMyself.getInfo().getStatus().equalsIgnoreCase("active")) {
@@ -72,13 +72,13 @@ public class EventsWebSocketAuthenticationFilter implements Filter {
 
     // Check if carbonioFeatureWscEnabled is in features list
     boolean wscEnabled =
-        userMyself.getFeaturesList().contains(CarbonioAttribute.FEATURE_WSC_ENABLED.getValue());
+        userMyself.getFeatures().contains(CarbonioAttribute.FEATURE_WSC_ENABLED.getValue());
     if (!wscEnabled) {
       ChatsLogger.warn("Websocket authentication failed: WSC feature not enabled for user");
       httpServletResponse.setStatus(Status.UNAUTHORIZED.getStatusCode());
       return;
     }
-    Map<String, String> capabilities = userMyself.getCapabilitiesMap();
+    Map<String, String> capabilities = userMyself.getCapabilities();
 
     String userId = userMyself.getInfo().getUserId();
     httpRequest.getSession().setAttribute("userId", userId);

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationServiceTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationServiceTest.java
@@ -6,7 +6,7 @@ package com.zextras.carbonio.chats.core.infrastructure.authentication.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import com.zextras.carbonio.chats.core.annotations.UnitTest;
@@ -76,7 +76,7 @@ class UserManagementAuthenticationServiceTest {
               "active",
               "carbonioFeatureWscEnabled");
 
-      when(userResourceApi.internalUsersMyselfGet(anyMap())).thenReturn(mockUser);
+      when(userResourceApi.internalUsersMyselfGet(anyString())).thenReturn(mockUser);
 
       Optional<MyselfDto> userMyself =
           userManagementAuthenticationService.getUserMyself("tokenz");
@@ -89,7 +89,7 @@ class UserManagementAuthenticationServiceTest {
     @Test
     @DisplayName("Returns an empty optional if the token could not be verified")
     void getUserMyself_testFailingToken() throws ApiException {
-      when(userResourceApi.internalUsersMyselfGet(anyMap()))
+      when(userResourceApi.internalUsersMyselfGet(anyString()))
           .thenThrow(new ApiException(401, "Unauthorized"));
 
       Optional<MyselfDto> userMyself =
@@ -119,7 +119,7 @@ class UserManagementAuthenticationServiceTest {
     @Test
     @DisplayName("Returns an empty optional if the validation fails for a generic error")
     void getUserMyself_testGenericFailure() throws ApiException {
-      when(userResourceApi.internalUsersMyselfGet(anyMap()))
+      when(userResourceApi.internalUsersMyselfGet(anyString()))
           .thenThrow(new ApiException(500, "Internal Server Error"));
 
       Optional<MyselfDto> userMyself =
@@ -146,12 +146,12 @@ class UserManagementAuthenticationServiceTest {
               "active",
               "carbonioFeatureWscEnabled");
 
-      when(userResourceApi.internalUsersMyselfGet(anyMap())).thenReturn(mockUser);
+      when(userResourceApi.internalUsersMyselfGet(anyString())).thenReturn(mockUser);
 
       Optional<MyselfDto> userProfile =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
-      verify(userResourceApi, times(1)).internalUsersMyselfGet(anyMap());
+      verify(userResourceApi, times(1)).internalUsersMyselfGet(anyString());
 
       assertTrue(userProfile.isPresent());
       assertEquals("my-user-id", userProfile.get().getInfo().getUserId());
@@ -174,13 +174,13 @@ class UserManagementAuthenticationServiceTest {
               "active",
               "carbonioFeatureWscEnabled");
 
-      when(userResourceApi.internalUsersMyselfGet(anyMap())).thenReturn(mockUser);
+      when(userResourceApi.internalUsersMyselfGet(anyString())).thenReturn(mockUser);
 
       userManagementAuthenticationService.getUserMyself("tokenz");
       Optional<MyselfDto> userProfile =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
-      verify(userResourceApi, times(2)).internalUsersMyselfGet(anyMap());
+      verify(userResourceApi, times(2)).internalUsersMyselfGet(anyString());
 
       assertTrue(userProfile.isPresent());
       assertEquals("my-user-id", userProfile.get().getInfo().getUserId());
@@ -193,13 +193,13 @@ class UserManagementAuthenticationServiceTest {
     @Test
     @DisplayName("Returns an empty optional if the token is not authenticated")
     void getUserProfile_testTokenNotAuthenticated() throws ApiException {
-      when(userResourceApi.internalUsersMyselfGet(anyMap()))
+      when(userResourceApi.internalUsersMyselfGet(anyString()))
           .thenThrow(new ApiException(404, "Not Found"));
 
       Optional<MyselfDto> userProfile =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
-      verify(userResourceApi, times(1)).internalUsersMyselfGet(anyMap());
+      verify(userResourceApi, times(1)).internalUsersMyselfGet(anyString());
 
       assertTrue(userProfile.isEmpty());
     }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationServiceTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationServiceTest.java
@@ -82,7 +82,7 @@ class UserManagementAuthenticationServiceTest {
               "active",
               "carbonioFeatureWscEnabled");
 
-      when(userResourceApi.internalUsersMyselfGet(anyString())).thenReturn(mockUser);
+      when(userResourceApi.internalUsersMyselfGet(any(), anyString())).thenReturn(mockUser);
 
       Optional<MyselfDto> userMyself =
           userManagementAuthenticationService.getUserMyself("tokenz");
@@ -95,7 +95,7 @@ class UserManagementAuthenticationServiceTest {
     @Test
     @DisplayName("Returns an empty optional if the token could not be verified")
     void getUserMyself_testFailingToken() throws ApiException {
-      when(userResourceApi.internalUsersMyselfGet(anyString()))
+      when(userResourceApi.internalUsersMyselfGet(any(), anyString()))
           .thenThrow(new ApiException(401, "Unauthorized"));
 
       Optional<MyselfDto> userMyself =
@@ -125,7 +125,7 @@ class UserManagementAuthenticationServiceTest {
     @Test
     @DisplayName("Throws an authentication exception if the validation fails for a generic error")
     void getUserMyself_testGenericFailure() throws ApiException {
-      when(userResourceApi.internalUsersMyselfGet(anyString()))
+      when(userResourceApi.internalUsersMyselfGet(any(), anyString()))
           .thenThrow(new ApiException(500, "Internal Server Error"));
 
       assertThrows(
@@ -138,7 +138,7 @@ class UserManagementAuthenticationServiceTest {
         "Throws an authentication exception when the call fails at the transport level"
             + " (code 0, e.g. connection refused/timeout)")
     void getUserMyself_testTransportFailure() throws ApiException {
-      when(userResourceApi.internalUsersMyselfGet(anyString()))
+      when(userResourceApi.internalUsersMyselfGet(any(), anyString()))
           .thenThrow(new ApiException(new IOException("Connection refused")));
 
       assertThrows(
@@ -164,12 +164,12 @@ class UserManagementAuthenticationServiceTest {
               "active",
               "carbonioFeatureWscEnabled");
 
-      when(userResourceApi.internalUsersMyselfGet(anyString())).thenReturn(mockUser);
+      when(userResourceApi.internalUsersMyselfGet(any(), anyString())).thenReturn(mockUser);
 
       Optional<MyselfDto> userProfile =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
-      verify(userResourceApi, times(1)).internalUsersMyselfGet(anyString());
+      verify(userResourceApi, times(1)).internalUsersMyselfGet(any(), anyString());
 
       assertTrue(userProfile.isPresent());
       assertEquals("my-user-id", userProfile.get().getInfo().getUserId());
@@ -192,13 +192,13 @@ class UserManagementAuthenticationServiceTest {
               "active",
               "carbonioFeatureWscEnabled");
 
-      when(userResourceApi.internalUsersMyselfGet(anyString())).thenReturn(mockUser);
+      when(userResourceApi.internalUsersMyselfGet(any(), anyString())).thenReturn(mockUser);
 
       userManagementAuthenticationService.getUserMyself("tokenz");
       Optional<MyselfDto> userProfile =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
-      verify(userResourceApi, times(2)).internalUsersMyselfGet(anyString());
+      verify(userResourceApi, times(2)).internalUsersMyselfGet(any(), anyString());
 
       assertTrue(userProfile.isPresent());
       assertEquals("my-user-id", userProfile.get().getInfo().getUserId());
@@ -211,13 +211,13 @@ class UserManagementAuthenticationServiceTest {
     @Test
     @DisplayName("Returns an empty optional only for a genuine 401 (invalid credentials)")
     void getUserProfile_testTokenNotAuthenticated() throws ApiException {
-      when(userResourceApi.internalUsersMyselfGet(anyString()))
+      when(userResourceApi.internalUsersMyselfGet(any(), anyString()))
           .thenThrow(new ApiException(401, "Unauthorized"));
 
       Optional<MyselfDto> userProfile =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
-      verify(userResourceApi, times(1)).internalUsersMyselfGet(anyString());
+      verify(userResourceApi, times(1)).internalUsersMyselfGet(any(), anyString());
 
       assertTrue(userProfile.isEmpty());
     }
@@ -225,7 +225,7 @@ class UserManagementAuthenticationServiceTest {
     @Test
     @DisplayName("Throws an authentication exception for an unexpected (non-401) status code")
     void getUserProfile_testUnexpectedStatusCode() throws ApiException {
-      when(userResourceApi.internalUsersMyselfGet(anyString()))
+      when(userResourceApi.internalUsersMyselfGet(any(), anyString()))
           .thenThrow(new ApiException(404, "Not Found"));
 
       assertThrows(

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationServiceTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationServiceTest.java
@@ -4,17 +4,23 @@
 
 package com.zextras.carbonio.chats.core.infrastructure.authentication.impl;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import com.zextras.carbonio.chats.core.annotations.UnitTest;
+import com.zextras.carbonio.chats.core.exception.AuthenticationException;
 import com.zextras.carbonio.chats.core.web.utility.HttpClient;
 import com.zextras.carbonio.user_management.sdk.rest.ApiException;
 import com.zextras.carbonio.user_management.sdk.rest.api.UserResourceApi;
 import com.zextras.carbonio.user_management.sdk.rest.model.MyselfDto;
 import com.zextras.carbonio.user_management.sdk.rest.model.UserInfoDto;
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -117,15 +123,27 @@ class UserManagementAuthenticationServiceTest {
     }
 
     @Test
-    @DisplayName("Returns an empty optional if the validation fails for a generic error")
+    @DisplayName("Throws an authentication exception if the validation fails for a generic error")
     void getUserMyself_testGenericFailure() throws ApiException {
       when(userResourceApi.internalUsersMyselfGet(anyString()))
           .thenThrow(new ApiException(500, "Internal Server Error"));
 
-      Optional<MyselfDto> userMyself =
-          userManagementAuthenticationService.getUserMyself("tokenz");
+      assertThrows(
+          AuthenticationException.class,
+          () -> userManagementAuthenticationService.getUserMyself("tokenz"));
+    }
 
-      assertTrue(userMyself.isEmpty());
+    @Test
+    @DisplayName(
+        "Throws an authentication exception when the call fails at the transport level"
+            + " (code 0, e.g. connection refused/timeout)")
+    void getUserMyself_testTransportFailure() throws ApiException {
+      when(userResourceApi.internalUsersMyselfGet(anyString()))
+          .thenThrow(new ApiException(new IOException("Connection refused")));
+
+      assertThrows(
+          AuthenticationException.class,
+          () -> userManagementAuthenticationService.getUserMyself("tokenz"));
     }
   }
 
@@ -191,10 +209,10 @@ class UserManagementAuthenticationServiceTest {
     }
 
     @Test
-    @DisplayName("Returns an empty optional if the token is not authenticated")
+    @DisplayName("Returns an empty optional only for a genuine 401 (invalid credentials)")
     void getUserProfile_testTokenNotAuthenticated() throws ApiException {
       when(userResourceApi.internalUsersMyselfGet(anyString()))
-          .thenThrow(new ApiException(404, "Not Found"));
+          .thenThrow(new ApiException(401, "Unauthorized"));
 
       Optional<MyselfDto> userProfile =
           userManagementAuthenticationService.getUserMyself("tokenz");
@@ -202,6 +220,40 @@ class UserManagementAuthenticationServiceTest {
       verify(userResourceApi, times(1)).internalUsersMyselfGet(anyString());
 
       assertTrue(userProfile.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Throws an authentication exception for an unexpected (non-401) status code")
+    void getUserProfile_testUnexpectedStatusCode() throws ApiException {
+      when(userResourceApi.internalUsersMyselfGet(anyString()))
+          .thenThrow(new ApiException(404, "Not Found"));
+
+      assertThrows(
+          AuthenticationException.class,
+          () -> userManagementAuthenticationService.getUserMyself("tokenz"));
+    }
+  }
+
+  @Nested
+  @DisplayName("Is alive tests")
+  class IsAliveTests {
+
+    @Test
+    @DisplayName(
+        "Reports the dependency as unhealthy, without throwing, when User Management is"
+            + " genuinely unreachable (connection refused)")
+    void isAlive_testUnreachable() throws IOException {
+      int closedPort;
+      try (ServerSocket socket = new ServerSocket(0)) {
+        closedPort = socket.getLocalPort();
+      }
+      UserManagementAuthenticationService serviceWithRealClient =
+          new UserManagementAuthenticationService(
+              userResourceApi, new HttpClient(), "http://127.0.0.1:" + closedPort);
+
+      boolean isAlive = assertDoesNotThrow(serviceWithRealClient::isAlive);
+
+      assertFalse(isAlive);
     }
   }
 }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationServiceTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/authentication/impl/UserManagementAuthenticationServiceTest.java
@@ -6,19 +6,15 @@ package com.zextras.carbonio.chats.core.infrastructure.authentication.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.*;
 
 import com.zextras.carbonio.chats.core.annotations.UnitTest;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUserMyselfRequest;
-import com.zextras.carbonio.user_management.sdk.grpc.UserInfoProto;
-import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc.UserManagementServiceBlockingStub;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfProto;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfResponse;
-import com.zextras.carbonio.user_management.sdk.grpc.UserTypeProto;
-import io.grpc.ManagedChannel;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
+import com.zextras.carbonio.chats.core.web.utility.HttpClient;
+import com.zextras.carbonio.user_management.sdk.rest.ApiException;
+import com.zextras.carbonio.user_management.sdk.rest.api.UserResourceApi;
+import com.zextras.carbonio.user_management.sdk.rest.model.MyselfDto;
+import com.zextras.carbonio.user_management.sdk.rest.model.UserInfoDto;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,40 +23,40 @@ import org.junit.jupiter.api.Test;
 @UnitTest
 class UserManagementAuthenticationServiceTest {
 
+  private static final String USER_MANAGEMENT_BASE_URL = "http://127.78.0.2:20001";
+
   private UserManagementAuthenticationService userManagementAuthenticationService;
-  private UserManagementServiceBlockingStub userManagementStub;
-  private ManagedChannel userManagementChannel;
+  private UserResourceApi userResourceApi;
 
   public UserManagementAuthenticationServiceTest() {
-    this.userManagementStub = mock(UserManagementServiceBlockingStub.class);
-    this.userManagementChannel = mock(ManagedChannel.class);
+    this.userResourceApi = mock(UserResourceApi.class);
+    HttpClient httpClient = mock(HttpClient.class);
     this.userManagementAuthenticationService =
         new UserManagementAuthenticationService(
-            userManagementStub, userManagementChannel);
+            userResourceApi, httpClient, USER_MANAGEMENT_BASE_URL);
   }
 
-  private UserMyselfProto buildUserMyselfProto(
-      String userId, String email, String fullName, String domain,
-      UserTypeProto type, String status, String... features) {
-    UserInfoProto info = UserInfoProto.newBuilder()
-        .setUserId(userId)
-        .setEmail(email)
-        .setFullName(fullName)
-        .setDomain(domain)
-        .setType(type)
-        .setStatus(status)
-        .build();
-    UserMyselfProto.Builder builder = UserMyselfProto.newBuilder()
-        .setInfo(info)
-        .setLocale("en");
+  private MyselfDto buildMyselfDto(
+      String userId,
+      String email,
+      String fullName,
+      String domain,
+      String type,
+      String status,
+      String... features) {
+    UserInfoDto info =
+        new UserInfoDto()
+            .userId(userId)
+            .email(email)
+            .fullName(fullName)
+            .domain(domain)
+            .type(type)
+            .status(status);
+    MyselfDto myself = new MyselfDto().info(info).locale("en");
     for (String feature : features) {
-      builder.addFeatures(feature);
+      myself.addFeaturesItem(feature);
     }
-    return builder.build();
-  }
-
-  private UserMyselfResponse buildUserMyselfResponse(UserMyselfProto userMyself) {
-    return UserMyselfResponse.newBuilder().setUser(userMyself).build();
+    return myself;
   }
 
   @Nested
@@ -69,15 +65,20 @@ class UserManagementAuthenticationServiceTest {
 
     @Test
     @DisplayName("Returns the authenticated user if validation was successful")
-    void getUserMyself_testOk() {
-      UserMyselfProto mockUser = buildUserMyselfProto(
-          "myUser", "myUser@example.com", "Test User", "example.com",
-          UserTypeProto.INTERNAL, "active", "carbonioFeatureWscEnabled");
+    void getUserMyself_testOk() throws ApiException {
+      MyselfDto mockUser =
+          buildMyselfDto(
+              "myUser",
+              "myUser@example.com",
+              "Test User",
+              "example.com",
+              "INTERNAL",
+              "active",
+              "carbonioFeatureWscEnabled");
 
-      when(userManagementStub.getUserMyself(any(GetUserMyselfRequest.class)))
-          .thenReturn(buildUserMyselfResponse(mockUser));
+      when(userResourceApi.internalUsersMyselfGet(anyMap())).thenReturn(mockUser);
 
-      Optional<UserMyselfProto> userMyself =
+      Optional<MyselfDto> userMyself =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
       assertTrue(userMyself.isPresent());
@@ -87,11 +88,11 @@ class UserManagementAuthenticationServiceTest {
 
     @Test
     @DisplayName("Returns an empty optional if the token could not be verified")
-    void getUserMyself_testFailingToken() {
-      when(userManagementStub.getUserMyself(any(GetUserMyselfRequest.class)))
-          .thenThrow(new StatusRuntimeException(Status.UNAUTHENTICATED));
+    void getUserMyself_testFailingToken() throws ApiException {
+      when(userResourceApi.internalUsersMyselfGet(anyMap()))
+          .thenThrow(new ApiException(401, "Unauthorized"));
 
-      Optional<UserMyselfProto> userMyself =
+      Optional<MyselfDto> userMyself =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
       assertTrue(userMyself.isEmpty());
@@ -100,7 +101,7 @@ class UserManagementAuthenticationServiceTest {
     @Test
     @DisplayName("Returns an empty optional if credential is null")
     void getUserMyself_testEmptyCredentials() {
-      Optional<UserMyselfProto> userMyself =
+      Optional<MyselfDto> userMyself =
           userManagementAuthenticationService.getUserMyself(null);
 
       assertTrue(userMyself.isEmpty());
@@ -109,7 +110,7 @@ class UserManagementAuthenticationServiceTest {
     @Test
     @DisplayName("Returns an empty optional if the token is not present")
     void getUserMyself_testNoZmAuthToken() {
-      Optional<UserMyselfProto> userMyself =
+      Optional<MyselfDto> userMyself =
           userManagementAuthenticationService.getUserMyself(null);
 
       assertTrue(userMyself.isEmpty());
@@ -117,11 +118,11 @@ class UserManagementAuthenticationServiceTest {
 
     @Test
     @DisplayName("Returns an empty optional if the validation fails for a generic error")
-    void getUserMyself_testGenericFailure() {
-      when(userManagementStub.getUserMyself(any(GetUserMyselfRequest.class)))
-          .thenThrow(new StatusRuntimeException(Status.INTERNAL));
+    void getUserMyself_testGenericFailure() throws ApiException {
+      when(userResourceApi.internalUsersMyselfGet(anyMap()))
+          .thenThrow(new ApiException(500, "Internal Server Error"));
 
-      Optional<UserMyselfProto> userMyself =
+      Optional<MyselfDto> userMyself =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
       assertTrue(userMyself.isEmpty());
@@ -134,61 +135,71 @@ class UserManagementAuthenticationServiceTest {
 
     @Test
     @DisplayName("Returns the authenticated user's info if user management successfully returns it")
-    void getUserProfile_testOk() {
-      UserMyselfProto mockUser = buildUserMyselfProto(
-          "my-user-id", "myuser@example.com", "My User", "example.com",
-          UserTypeProto.INTERNAL, "active", "carbonioFeatureWscEnabled");
+    void getUserProfile_testOk() throws ApiException {
+      MyselfDto mockUser =
+          buildMyselfDto(
+              "my-user-id",
+              "myuser@example.com",
+              "My User",
+              "example.com",
+              "INTERNAL",
+              "active",
+              "carbonioFeatureWscEnabled");
 
-      when(userManagementStub.getUserMyself(any(GetUserMyselfRequest.class)))
-          .thenReturn(buildUserMyselfResponse(mockUser));
+      when(userResourceApi.internalUsersMyselfGet(anyMap())).thenReturn(mockUser);
 
-      Optional<UserMyselfProto> userProfile =
+      Optional<MyselfDto> userProfile =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
-      verify(userManagementStub, times(1)).getUserMyself(any(GetUserMyselfRequest.class));
+      verify(userResourceApi, times(1)).internalUsersMyselfGet(anyMap());
 
       assertTrue(userProfile.isPresent());
       assertEquals("my-user-id", userProfile.get().getInfo().getUserId());
       assertEquals("myuser@example.com", userProfile.get().getInfo().getEmail());
       assertEquals("My User", userProfile.get().getInfo().getFullName());
       assertEquals("example.com", userProfile.get().getInfo().getDomain());
-      assertEquals(UserTypeProto.INTERNAL, userProfile.get().getInfo().getType());
+      assertEquals("INTERNAL", userProfile.get().getInfo().getType());
     }
 
     @Test
     @DisplayName("Calls UM service on every request (no local cache)")
-    void getUserProfile_testNoLocalCache() {
-      UserMyselfProto mockUser = buildUserMyselfProto(
-          "my-user-id", "myuser@example.com", "My User", "example.com",
-          UserTypeProto.INTERNAL, "active", "carbonioFeatureWscEnabled");
+    void getUserProfile_testNoLocalCache() throws ApiException {
+      MyselfDto mockUser =
+          buildMyselfDto(
+              "my-user-id",
+              "myuser@example.com",
+              "My User",
+              "example.com",
+              "INTERNAL",
+              "active",
+              "carbonioFeatureWscEnabled");
 
-      when(userManagementStub.getUserMyself(any(GetUserMyselfRequest.class)))
-          .thenReturn(buildUserMyselfResponse(mockUser));
+      when(userResourceApi.internalUsersMyselfGet(anyMap())).thenReturn(mockUser);
 
       userManagementAuthenticationService.getUserMyself("tokenz");
-      Optional<UserMyselfProto> userProfile =
+      Optional<MyselfDto> userProfile =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
-      verify(userManagementStub, times(2)).getUserMyself(any(GetUserMyselfRequest.class));
+      verify(userResourceApi, times(2)).internalUsersMyselfGet(anyMap());
 
       assertTrue(userProfile.isPresent());
       assertEquals("my-user-id", userProfile.get().getInfo().getUserId());
       assertEquals("myuser@example.com", userProfile.get().getInfo().getEmail());
       assertEquals("My User", userProfile.get().getInfo().getFullName());
       assertEquals("example.com", userProfile.get().getInfo().getDomain());
-      assertEquals(UserTypeProto.INTERNAL, userProfile.get().getInfo().getType());
+      assertEquals("INTERNAL", userProfile.get().getInfo().getType());
     }
 
     @Test
     @DisplayName("Returns an empty optional if the token is not authenticated")
-    void getUserProfile_testTokenNotAuthenticated() {
-      when(userManagementStub.getUserMyself(any(GetUserMyselfRequest.class)))
-          .thenThrow(new StatusRuntimeException(Status.NOT_FOUND));
+    void getUserProfile_testTokenNotAuthenticated() throws ApiException {
+      when(userResourceApi.internalUsersMyselfGet(anyMap()))
+          .thenThrow(new ApiException(404, "Not Found"));
 
-      Optional<UserMyselfProto> userProfile =
+      Optional<MyselfDto> userProfile =
           userManagementAuthenticationService.getUserMyself("tokenz");
 
-      verify(userManagementStub, times(1)).getUserMyself(any(GetUserMyselfRequest.class));
+      verify(userResourceApi, times(1)).internalUsersMyselfGet(anyMap());
 
       assertTrue(userProfile.isEmpty());
     }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingServiceTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingServiceTest.java
@@ -4,7 +4,9 @@
 
 package com.zextras.carbonio.chats.core.infrastructure.profiling.impl;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -22,6 +24,8 @@ import com.zextras.carbonio.chats.core.web.utility.HttpClient;
 import com.zextras.carbonio.user_management.sdk.rest.ApiException;
 import com.zextras.carbonio.user_management.sdk.rest.api.UserResourceApi;
 import com.zextras.carbonio.user_management.sdk.rest.model.UserInfoDto;
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -122,6 +126,29 @@ class UserManagementProfilingServiceTest {
           () ->
               profilingService.getById(
                   UserPrincipal.create(randomUUID).authToken("cookie"), randomUUID));
+    }
+  }
+
+  @Nested
+  @DisplayName("Is alive tests")
+  class IsAliveTests {
+
+    @Test
+    @DisplayName(
+        "Reports the dependency as unhealthy, without throwing, when User Management is"
+            + " genuinely unreachable (connection refused)")
+    void isAlive_testUnreachable() throws IOException {
+      int closedPort;
+      try (ServerSocket socket = new ServerSocket(0)) {
+        closedPort = socket.getLocalPort();
+      }
+      UserManagementProfilingService serviceWithRealClient =
+          new UserManagementProfilingService(
+              userResourceApi, new HttpClient(), "http://127.0.0.1:" + closedPort);
+
+      boolean isAlive = assertDoesNotThrow(serviceWithRealClient::isAlive);
+
+      assertFalse(isAlive);
     }
   }
 }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingServiceTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/infrastructure/profiling/impl/UserManagementProfilingServiceTest.java
@@ -7,7 +7,7 @@ package com.zextras.carbonio.chats.core.infrastructure.profiling.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
@@ -18,14 +18,10 @@ import com.zextras.carbonio.chats.core.data.type.UserType;
 import com.zextras.carbonio.chats.core.exception.ForbiddenException;
 import com.zextras.carbonio.chats.core.exception.ProfilingException;
 import com.zextras.carbonio.chats.core.web.security.UserPrincipal;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUserByIdRequest;
-import com.zextras.carbonio.user_management.sdk.grpc.UserInfoProto;
-import com.zextras.carbonio.user_management.sdk.grpc.UserInfoResponse;
-import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc.UserManagementServiceBlockingStub;
-import com.zextras.carbonio.user_management.sdk.grpc.UserTypeProto;
-import io.grpc.ManagedChannel;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
+import com.zextras.carbonio.chats.core.web.utility.HttpClient;
+import com.zextras.carbonio.user_management.sdk.rest.ApiException;
+import com.zextras.carbonio.user_management.sdk.rest.api.UserResourceApi;
+import com.zextras.carbonio.user_management.sdk.rest.model.UserInfoDto;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -36,33 +32,32 @@ import org.junit.jupiter.api.Test;
 @UnitTest
 class UserManagementProfilingServiceTest {
 
+  private static final String USER_MANAGEMENT_BASE_URL = "http://127.78.0.2:20001";
+
   private final UserManagementProfilingService profilingService;
-  private final UserManagementServiceBlockingStub userManagementStub;
-  private final ManagedChannel userManagementChannel;
+  private final UserResourceApi userResourceApi;
 
   public UserManagementProfilingServiceTest() {
-    this.userManagementStub = mock(UserManagementServiceBlockingStub.class);
-    this.userManagementChannel = mock(ManagedChannel.class);
+    this.userResourceApi = mock(UserResourceApi.class);
+    HttpClient httpClient = mock(HttpClient.class);
     this.profilingService =
-        new UserManagementProfilingService(userManagementStub, userManagementChannel);
+        new UserManagementProfilingService(userResourceApi, httpClient, USER_MANAGEMENT_BASE_URL);
   }
 
   @AfterEach
   public void cleanup() {
-    reset(userManagementStub);
+    reset(userResourceApi);
   }
 
-  private UserInfoProto buildUserInfoProto(
-      String userId, String email, String fullName, String domain,
-      String status, UserTypeProto type) {
-    return UserInfoProto.newBuilder()
-        .setUserId(userId)
-        .setEmail(email)
-        .setFullName(fullName)
-        .setDomain(domain)
-        .setStatus(status)
-        .setType(type)
-        .build();
+  private UserInfoDto buildUserInfoDto(
+      String userId, String email, String fullName, String domain, String status, String type) {
+    return new UserInfoDto()
+        .userId(userId)
+        .email(email)
+        .fullName(fullName)
+        .domain(domain)
+        .status(status)
+        .type(type);
   }
 
   @Nested
@@ -71,13 +66,13 @@ class UserManagementProfilingServiceTest {
 
     @Test
     @DisplayName("Returns the requested user correctly mapped")
-    void getById_testOk() {
+    void getById_testOk() throws ApiException {
       UUID randomUUID = UUID.randomUUID();
-      UserInfoProto userInfo = buildUserInfoProto(
-          randomUUID.toString(), "email@test.com", "name hello", "mydomain.com",
-          "active", UserTypeProto.INTERNAL);
-      when(userManagementStub.getUserById(any(GetUserByIdRequest.class)))
-          .thenReturn(UserInfoResponse.newBuilder().setUser(userInfo).build());
+      UserInfoDto userInfo =
+          buildUserInfoDto(
+              randomUUID.toString(), "email@test.com", "name hello", "mydomain.com", "active",
+              "INTERNAL");
+      when(userResourceApi.internalUsersIdUserIdGet(anyString())).thenReturn(userInfo);
 
       Optional<UserProfile> userProfile =
           profilingService.getById(
@@ -93,10 +88,10 @@ class UserManagementProfilingServiceTest {
 
     @Test
     @DisplayName("Returns an empty optional if the user was not found")
-    void getById_testNotFound() {
+    void getById_testNotFound() throws ApiException {
       UUID randomUUID = UUID.randomUUID();
-      when(userManagementStub.getUserById(any(GetUserByIdRequest.class)))
-          .thenThrow(new StatusRuntimeException(Status.NOT_FOUND));
+      when(userResourceApi.internalUsersIdUserIdGet(anyString()))
+          .thenThrow(new ApiException(404, "Not Found"));
 
       Optional<UserProfile> userProfile =
           profilingService.getById(
@@ -118,10 +113,10 @@ class UserManagementProfilingServiceTest {
 
     @Test
     @DisplayName("Throws an exception when the call fails for any other reason")
-    void getById_testException() {
+    void getById_testException() throws ApiException {
       UUID randomUUID = UUID.randomUUID();
-      when(userManagementStub.getUserById(any(GetUserByIdRequest.class)))
-          .thenThrow(new StatusRuntimeException(Status.INTERNAL));
+      when(userResourceApi.internalUsersIdUserIdGet(anyString()))
+          .thenThrow(new ApiException(500, "Internal Server Error"));
       assertThrows(
           ProfilingException.class,
           () ->

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/HealthcheckServiceImplTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/service/impl/HealthcheckServiceImplTest.java
@@ -4,14 +4,19 @@
 
 package com.zextras.carbonio.chats.core.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.zextras.carbonio.chats.core.annotations.UnitTest;
 import com.zextras.carbonio.chats.core.infrastructure.authentication.AuthenticationService;
+import com.zextras.carbonio.chats.core.infrastructure.authentication.impl.UserManagementAuthenticationService;
 import com.zextras.carbonio.chats.core.infrastructure.database.DatabaseInfoService;
 import com.zextras.carbonio.chats.core.infrastructure.event.EventDispatcher;
 import com.zextras.carbonio.chats.core.infrastructure.messaging.MessageDispatcher;
@@ -19,10 +24,14 @@ import com.zextras.carbonio.chats.core.infrastructure.profiling.ProfilingService
 import com.zextras.carbonio.chats.core.infrastructure.storage.StoragesService;
 import com.zextras.carbonio.chats.core.infrastructure.videoserver.VideoServerService;
 import com.zextras.carbonio.chats.core.infrastructure.preview.PreviewService;
+import com.zextras.carbonio.chats.core.web.utility.HttpClient;
 import com.zextras.carbonio.chats.model.DependencyHealthDto;
 import com.zextras.carbonio.chats.model.DependencyHealthTypeDto;
 import com.zextras.carbonio.chats.model.HealthStatusDto;
 import com.zextras.carbonio.chats.model.HealthStatusTypeDto;
+import com.zextras.carbonio.user_management.sdk.rest.api.UserResourceApi;
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -346,6 +355,77 @@ class HealthcheckServiceImplTest {
       assertTrue(dependencyHealthDto.containsAll(serviceHealth.getDependencies()));
     }
 
+    @Test
+    @DisplayName("Calls isAlive() on each dependency only once per getServiceHealth() invocation")
+    public void getServiceHealth_testNoRedundantIsAliveCalls() {
+      when(messageDispatcher.isAlive()).thenReturn(true);
+      when(databaseInfoService.isAlive()).thenReturn(true);
+      when(eventDispatcher.isAlive()).thenReturn(true);
+      when(storagesService.isAlive()).thenReturn(true);
+      when(previewService.isAlive()).thenReturn(true);
+      when(authenticationService.isAlive()).thenReturn(true);
+      when(profilingService.isAlive()).thenReturn(true);
+      when(videoServerService.isAlive()).thenReturn(true);
+
+      healthcheckService.getServiceHealth();
+
+      // Before the fix, HealthcheckServiceImpl called isAlive() on each dependency once per
+      // anyMatch pass in checkServiceStatus() plus once more in the DTO mapping: up to 3 real
+      // network round trips per dependency for a single /health request.
+      verify(authenticationService, times(1)).isAlive();
+      verify(profilingService, times(1)).isAlive();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("User Management unreachable regression tests")
+  class UserManagementUnreachableTests {
+
+    @Test
+    @DisplayName(
+        "getServiceHealth() returns ERROR with the auth dependency unhealthy instead of throwing"
+            + " (i.e. /health responds 200, not 500) when User Management is unreachable")
+    public void getServiceHealth_testUserManagementUnreachable() throws IOException {
+      when(messageDispatcher.isAlive()).thenReturn(true);
+      when(databaseInfoService.isAlive()).thenReturn(true);
+      when(eventDispatcher.isAlive()).thenReturn(true);
+      when(storagesService.isAlive()).thenReturn(true);
+      when(previewService.isAlive()).thenReturn(true);
+      when(profilingService.isAlive()).thenReturn(true);
+      when(videoServerService.isAlive()).thenReturn(true);
+
+      int closedPort;
+      try (ServerSocket socket = new ServerSocket(0)) {
+        closedPort = socket.getLocalPort();
+      }
+      AuthenticationService unreachableAuthenticationService =
+          new UserManagementAuthenticationService(
+              mock(UserResourceApi.class), new HttpClient(), "http://127.0.0.1:" + closedPort);
+
+      HealthcheckServiceImpl healthcheckServiceWithUnreachableUm =
+          new HealthcheckServiceImpl(
+              messageDispatcher,
+              databaseInfoService,
+              eventDispatcher,
+              storagesService,
+              previewService,
+              unreachableAuthenticationService,
+              profilingService,
+              videoServerService);
+
+      HealthStatusDto serviceHealth =
+          assertDoesNotThrow(healthcheckServiceWithUnreachableUm::getServiceHealth);
+
+      assertEquals(HealthStatusTypeDto.ERROR, serviceHealth.getStatus());
+      boolean authIsHealthy =
+          serviceHealth.getDependencies().stream()
+              .filter(dependency -> dependency.getName() == DependencyHealthTypeDto.AUTHENTICATION_SERVICE)
+              .findFirst()
+              .orElseThrow()
+              .isIsHealthy();
+      assertFalse(authIsHealthy);
+    }
   }
 
 }

--- a/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/web/security/AuthenticationFilterTest.java
+++ b/carbonio-ws-collaboration-core/src/test/java/com/zextras/carbonio/chats/core/web/security/AuthenticationFilterTest.java
@@ -17,9 +17,8 @@ import com.zextras.carbonio.chats.core.annotations.UnitTest;
 import com.zextras.carbonio.chats.core.data.type.UserType;
 import com.zextras.carbonio.chats.core.exception.UnauthorizedException;
 import com.zextras.carbonio.chats.core.infrastructure.authentication.AuthenticationService;
-import com.zextras.carbonio.user_management.sdk.grpc.UserInfoProto;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfProto;
-import com.zextras.carbonio.user_management.sdk.grpc.UserTypeProto;
+import com.zextras.carbonio.user_management.sdk.rest.model.MyselfDto;
+import com.zextras.carbonio.user_management.sdk.rest.model.UserInfoDto;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.Cookie;
 import java.util.Map;
@@ -41,25 +40,24 @@ class AuthenticationFilterTest {
     authenticationFilter = new AuthenticationFilter(authenticationService);
   }
 
-  private UserMyselfProto buildUserMyselfProto(
+  private MyselfDto buildMyselfDto(
       String userId, String email, String fullName, String domain,
-      UserTypeProto type, String status, Map<String, String> capabilities, String... features) {
-    UserInfoProto info = UserInfoProto.newBuilder()
-        .setUserId(userId)
-        .setEmail(email)
-        .setFullName(fullName)
-        .setDomain(domain)
-        .setType(type)
-        .setStatus(status)
-        .build();
-    UserMyselfProto.Builder builder = UserMyselfProto.newBuilder()
-        .setInfo(info)
-        .setLocale("en")
-        .putAllCapabilities(capabilities);
+      String type, String status, Map<String, String> capabilities, String... features) {
+    UserInfoDto info = new UserInfoDto()
+        .userId(userId)
+        .email(email)
+        .fullName(fullName)
+        .domain(domain)
+        .type(type)
+        .status(status);
+    MyselfDto myself = new MyselfDto()
+        .info(info)
+        .locale("en")
+        .capabilities(capabilities);
     for (String feature : features) {
-      builder.addFeatures(feature);
+      myself.addFeaturesItem(feature);
     }
-    return builder.build();
+    return myself;
   }
 
   @Nested
@@ -71,9 +69,9 @@ class AuthenticationFilterTest {
     void filter_testOk() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of("carbonioFeatureWscEnabled", "TRUE");
-      UserMyselfProto userMyself = buildUserMyselfProto(
+      MyselfDto userMyself = buildMyselfDto(
           userId.toString(), "user@example.com", "Test User", "example.com",
-          UserTypeProto.INTERNAL, "active", capabilities, "carbonioFeatureWscEnabled");
+          "INTERNAL", "active", capabilities, "carbonioFeatureWscEnabled");
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())
@@ -100,9 +98,9 @@ class AuthenticationFilterTest {
     void filter_testOkForGuestUser() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of("carbonioFeatureWscEnabled", "TRUE");
-      UserMyselfProto userMyself = buildUserMyselfProto(
+      MyselfDto userMyself = buildMyselfDto(
           userId.toString(), "guest@example.com", "Guest User", "example.com",
-          UserTypeProto.GUEST, "active", capabilities, "carbonioFeatureWscEnabled");
+          "GUEST", "active", capabilities, "carbonioFeatureWscEnabled");
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())
@@ -150,9 +148,9 @@ class AuthenticationFilterTest {
     void filter_testUserNotActive() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of("carbonioFeatureWscEnabled", "TRUE");
-      UserMyselfProto userMyself = buildUserMyselfProto(
+      MyselfDto userMyself = buildMyselfDto(
           userId.toString(), "user@example.com", "Test User", "example.com",
-          UserTypeProto.INTERNAL, "closed", capabilities, "carbonioFeatureWscEnabled");
+          "INTERNAL", "closed", capabilities, "carbonioFeatureWscEnabled");
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())
@@ -167,9 +165,9 @@ class AuthenticationFilterTest {
     void filter_testWscFeatureDisabledForInternalUser() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of("carbonioFeatureWscEnabled", "FALSE");
-      UserMyselfProto userMyself = buildUserMyselfProto(
+      MyselfDto userMyself = buildMyselfDto(
           userId.toString(), "user@example.com", "Test User", "example.com",
-          UserTypeProto.INTERNAL, "active", capabilities);
+          "INTERNAL", "active", capabilities);
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())
@@ -184,9 +182,9 @@ class AuthenticationFilterTest {
     void filter_testWscFeatureDisabledForGuestUser() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of("carbonioFeatureWscEnabled", "FALSE");
-      UserMyselfProto userMyself = buildUserMyselfProto(
+      MyselfDto userMyself = buildMyselfDto(
           userId.toString(), "user@example.com", "Test User", "example.com",
-          UserTypeProto.GUEST, "active", capabilities);
+          "GUEST", "active", capabilities);
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())
@@ -202,9 +200,9 @@ class AuthenticationFilterTest {
     void filter_testWscFeatureMissingForInternalUser() {
       UUID userId = UUID.randomUUID();
       Map<String, String> capabilities = Map.of();
-      UserMyselfProto userMyself = buildUserMyselfProto(
+      MyselfDto userMyself = buildMyselfDto(
           userId.toString(), "user@example.com", "Test User", "example.com",
-          UserTypeProto.INTERNAL, "active", capabilities);
+          "INTERNAL", "active", capabilities);
 
       ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
       when(requestContext.getCookies())

--- a/carbonio-ws-collaboration-it/pom.xml
+++ b/carbonio-ws-collaboration-it/pom.xml
@@ -59,12 +59,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-inprocess</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/config/TestModule.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/config/TestModule.java
@@ -8,7 +8,6 @@ import com.github.fridujo.rabbitmq.mock.MockConnectionFactory;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.google.inject.name.Named;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
@@ -16,12 +15,9 @@ import com.zextras.carbonio.chats.core.config.AppConfig;
 import com.zextras.carbonio.chats.core.exception.EventDispatcherException;
 import com.zextras.carbonio.chats.core.infrastructure.event.impl.RabbitConnectionPoolService;
 import com.zextras.carbonio.chats.core.web.socket.MessageBrokerVideoserverHealthMonitor;
-import com.zextras.carbonio.chats.it.tools.UserManagementMockServer;
 import com.zextras.carbonio.chats.it.utils.IntegrationTestUtils;
 import com.zextras.carbonio.chats.it.utils.MeetingTestUtils;
 import com.zextras.carbonio.chats.it.web.api.versioning.DummyVersionedApi;
-import io.grpc.ManagedChannel;
-import io.grpc.inprocess.InProcessChannelBuilder;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.ZoneId;
@@ -78,14 +74,5 @@ public class TestModule extends AbstractModule {
     } catch (IOException e) {
       throw new EventDispatcherException("Failed to create RabbitMQ channel", e);
     }
-  }
-
-  @Singleton
-  @Provides
-  @Named("userManagementChannel")
-  private ManagedChannel getUserManagementChannel() {
-    return InProcessChannelBuilder.forName(UserManagementMockServer.SERVER_NAME)
-        .directExecutor()
-        .build();
   }
 }

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/extensions/UserManagementExtension.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/extensions/UserManagementExtension.java
@@ -4,7 +4,9 @@
 
 package com.zextras.carbonio.chats.it.extensions;
 
+import com.zextras.carbonio.chats.core.config.ConfigName;
 import com.zextras.carbonio.chats.core.logging.ChatsLogger;
+import com.zextras.carbonio.chats.it.config.InMemoryConfigStore;
 import com.zextras.carbonio.chats.it.tools.UserManagementMockServer;
 import java.util.Optional;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -16,6 +18,8 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 
 public class UserManagementExtension implements BeforeAllCallback, ParameterResolver {
 
+  private static final String SERVER_HOST = "127.0.0.1";
+  private static final int SERVER_PORT = 7899;
   private static final Namespace EXTENSION_NAMESPACE =
       Namespace.create(UserManagementExtension.class);
   private static final String CLIENT_STORE_ENTRY = "user_management_client";
@@ -28,8 +32,12 @@ public class UserManagementExtension implements BeforeAllCallback, ParameterReso
         .getOrComputeIfAbsent(
             CLIENT_STORE_ENTRY,
             (key) -> {
-              ChatsLogger.debug("Starting User Management gRPC mock...");
-              return new UserManagementMockServer();
+              ChatsLogger.debug("Starting User Management mock...");
+              UserManagementMockServer client = new UserManagementMockServer(SERVER_PORT);
+              InMemoryConfigStore.set(ConfigName.USER_MANAGEMENT_HOST, SERVER_HOST);
+              InMemoryConfigStore.set(
+                  ConfigName.USER_MANAGEMENT_PORT, Integer.toString(SERVER_PORT));
+              return client;
             },
             UserManagementMockServer.class);
   }

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/tools/UserManagementMockServer.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/tools/UserManagementMockServer.java
@@ -4,80 +4,132 @@
 
 package com.zextras.carbonio.chats.it.tools;
 
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zextras.carbonio.chats.core.data.type.CarbonioAttribute;
+import com.zextras.carbonio.chats.core.data.type.UserType;
 import com.zextras.carbonio.chats.core.logging.ChatsLogger;
 import com.zextras.carbonio.chats.it.utils.MockedAccount;
 import com.zextras.carbonio.chats.it.utils.MockedAccount.MockUserProfile;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUserByIdRequest;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUserMyselfRequest;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUsersRequest;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUsersResponse;
-import com.zextras.carbonio.user_management.sdk.grpc.UserInfoProto;
-import com.zextras.carbonio.user_management.sdk.grpc.UserInfoResponse;
-import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfProto;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfResponse;
-import com.zextras.carbonio.user_management.sdk.grpc.UserTypeProto;
-import io.grpc.Server;
-import io.grpc.Status;
-import io.grpc.inprocess.InProcessServerBuilder;
-import io.grpc.stub.StreamObserver;
-import java.io.IOException;
+import com.zextras.carbonio.user_management.sdk.rest.model.MyselfDto;
+import com.zextras.carbonio.user_management.sdk.rest.model.UserInfoDto;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.Header;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.JsonBody;
 
-public class UserManagementMockServer implements CloseableResource {
+/**
+ * MockServer-backed stand-in for the User Management REST service. Replaces the previous
+ * in-process gRPC mock server: it stubs the {@code /internal/users/*} REST endpoints instead of
+ * implementing a gRPC service, but keeps the same in-memory-user seeding API
+ * ({@link #registerToken(String, MyselfDto)}, {@link #registerUserById(String, UserInfoDto)}) so
+ * existing tests don't need to change how they inject fixtures.
+ */
+public class UserManagementMockServer extends ClientAndServer implements CloseableResource {
 
-  public static final String SERVER_NAME = "user-management-mock-server";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  private final Server server;
-  private final MockUserManagementService service;
+  private final Map<String, UserInfoDto> userIdToInfo = new HashMap<>();
 
-  public UserManagementMockServer() {
-    this.service = new MockUserManagementService();
+  public UserManagementMockServer(Integer... ports) {
+    super(ports);
+    init();
+  }
+
+  public UserManagementMockServer(String remoteHost, Integer remotePort, Integer... ports) {
+    super(remoteHost, remotePort, ports);
+    init();
+  }
+
+  private void init() {
     registerMockedAccounts();
-    try {
-      this.server =
-          InProcessServerBuilder.forName(SERVER_NAME)
-              .directExecutor()
-              .addService(service)
-              .build()
-              .start();
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to start User Management gRPC in-process server", e);
-    }
+    mockBulkGetUsers();
+    setIsAliveResponse(true);
+  }
+
+  /**
+   * Stubs the {@code /q/health/live} liveness probe used by {@code isAlive()} in
+   * UserManagementAuthenticationService/UserManagementProfilingService. Defaults to alive at
+   * construction, mirroring the old in-process gRPC channel which always reported READY in tests.
+   */
+  public void setIsAliveResponse(boolean success) {
+    HttpRequest request = request().withMethod("GET").withPath("/q/health/live");
+    clear(request);
+    when(request).respond(response().withStatusCode(success ? 200 : 500));
   }
 
   private void registerMockedAccounts() {
     for (MockUserProfile account : MockedAccount.getAccounts()) {
-      UserTypeProto typeProto =
-          switch (account.getType()) {
-            case GUEST -> UserTypeProto.GUEST;
-            default -> UserTypeProto.INTERNAL;
-          };
+      String type = account.getType() == UserType.GUEST ? "GUEST" : "INTERNAL";
 
-      UserInfoProto userInfo =
-          UserInfoProto.newBuilder()
-              .setUserId(account.getId())
-              .setEmail(account.getEmail())
-              .setFullName(account.getName())
-              .setDomain(deriveDomain(account))
-              .setStatus("active")
-              .setType(typeProto)
-              .build();
+      UserInfoDto userInfo =
+          new UserInfoDto()
+              .userId(account.getId())
+              .email(account.getEmail())
+              .fullName(account.getName())
+              .domain(deriveDomain(account))
+              .status("active")
+              .type(type);
 
-      UserMyselfProto userMyself =
-          UserMyselfProto.newBuilder()
-              .setInfo(userInfo)
-              .setLocale("en")
-              .addFeatures("carbonioFeatureWscEnabled")
-              .putAllCapabilities(getDefaultCapabilities())
-              .build();
+      MyselfDto userMyself =
+          new MyselfDto().info(userInfo).locale("en").capabilities(getDefaultCapabilities());
+      userMyself.addFeaturesItem("carbonioFeatureWscEnabled");
 
-      service.registerToken(account.getToken(), userMyself);
-      service.registerUserById(account.getId(), userInfo);
+      registerToken(account.getToken(), userMyself);
+      registerUserById(account.getId(), userInfo);
     }
+  }
+
+  /** Stubs {@code GET /internal/users/myself} with the {@code ZM_AUTH_TOKEN} cookie for the given token. */
+  public void registerToken(String token, MyselfDto userMyself) {
+    HttpRequest request =
+        request()
+            .withMethod("GET")
+            .withPath("/internal/users/myself")
+            .withHeader(Header.header("Cookie", "ZM_AUTH_TOKEN=" + token));
+    clear(request);
+    when(request).respond(response().withStatusCode(200).withBody(JsonBody.json(userMyself)));
+  }
+
+  /**
+   * Stubs {@code GET /internal/users/id/{userId}} and registers the user so it is also returned
+   * by the bulk {@code POST /internal/users} endpoint.
+   */
+  public void registerUserById(String userId, UserInfoDto userInfo) {
+    userIdToInfo.put(userId, userInfo);
+    HttpRequest request = request().withMethod("GET").withPath("/internal/users/id/" + userId);
+    clear(request);
+    when(request).respond(response().withStatusCode(200).withBody(JsonBody.json(userInfo)));
+  }
+
+  /**
+   * Stubs {@code POST /internal/users} once with a dynamic callback: it reads the requested user
+   * ids from the JSON request body and returns whichever of them are currently registered, mirroring
+   * the previous gRPC mock's {@code getUsers} behaviour.
+   */
+  private void mockBulkGetUsers() {
+    when(request().withMethod("POST").withPath("/internal/users"))
+        .respond(
+            httpRequest -> {
+              List<String> requestedIds =
+                  OBJECT_MAPPER.readValue(
+                      httpRequest.getBodyAsString(), new TypeReference<List<String>>() {});
+              List<UserInfoDto> matched =
+                  requestedIds.stream()
+                      .map(userIdToInfo::get)
+                      .filter(Objects::nonNull)
+                      .collect(Collectors.toList());
+              return response().withStatusCode(200).withBody(JsonBody.json(matched));
+            });
   }
 
   private static Map<String, String> getDefaultCapabilities() {
@@ -108,74 +160,9 @@ public class UserManagementMockServer implements CloseableResource {
     return "";
   }
 
-  /**
-   * Returns the mock service implementation, allowing tests to register additional dynamic
-   * responses (e.g., for bulk user lookups).
-   */
-  public MockUserManagementService getService() {
-    return service;
-  }
-
   @Override
   public void close() {
-    ChatsLogger.debug("Stopping User Management gRPC mock...");
-    server.shutdownNow();
-  }
-
-  public static class MockUserManagementService
-      extends UserManagementServiceGrpc.UserManagementServiceImplBase {
-
-    private final Map<String, UserMyselfProto> tokenToUserMyself = new HashMap<>();
-    private final Map<String, UserInfoProto> userIdToInfo = new HashMap<>();
-
-    public void registerToken(String token, UserMyselfProto userMyself) {
-      tokenToUserMyself.put(token, userMyself);
-    }
-
-    public void registerUserById(String userId, UserInfoProto userInfo) {
-      userIdToInfo.put(userId, userInfo);
-    }
-
-    @Override
-    public void getUserMyself(
-        GetUserMyselfRequest request, StreamObserver<UserMyselfResponse> responseObserver) {
-      String token = request.getToken();
-      UserMyselfProto userMyself = tokenToUserMyself.get(token);
-      if (userMyself == null) {
-        responseObserver.onError(
-            Status.UNAUTHENTICATED.withDescription("Invalid token").asRuntimeException());
-        return;
-      }
-      responseObserver.onNext(UserMyselfResponse.newBuilder().setUser(userMyself).build());
-      responseObserver.onCompleted();
-    }
-
-    @Override
-    public void getUserById(
-        GetUserByIdRequest request, StreamObserver<UserInfoResponse> responseObserver) {
-      String userId = request.getUserId();
-      UserInfoProto userInfo = userIdToInfo.get(userId);
-      if (userInfo == null) {
-        responseObserver.onError(
-            Status.NOT_FOUND.withDescription("User not found").asRuntimeException());
-        return;
-      }
-      responseObserver.onNext(UserInfoResponse.newBuilder().setUser(userInfo).build());
-      responseObserver.onCompleted();
-    }
-
-    @Override
-    public void getUsers(
-        GetUsersRequest request, StreamObserver<GetUsersResponse> responseObserver) {
-      GetUsersResponse.Builder responseBuilder = GetUsersResponse.newBuilder();
-      for (String userId : request.getUserIdsList()) {
-        UserInfoProto userInfo = userIdToInfo.get(userId);
-        if (userInfo != null) {
-          responseBuilder.addUsers(userInfo);
-        }
-      }
-      responseObserver.onNext(responseBuilder.build());
-      responseObserver.onCompleted();
-    }
+    ChatsLogger.debug("Stopping User Management mock...");
+    super.close();
   }
 }

--- a/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/tools/UserManagementMockServer.java
+++ b/carbonio-ws-collaboration-it/src/test/java/com/zextras/carbonio/chats/it/tools/UserManagementMockServer.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.mockserver.integration.ClientAndServer;
+import org.mockserver.matchers.Times;
+import org.mockserver.matchers.TimeToLive;
 import org.mockserver.model.Header;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.JsonBody;
@@ -52,6 +54,7 @@ public class UserManagementMockServer extends ClientAndServer implements Closeab
 
   private void init() {
     registerMockedAccounts();
+    registerUnauthorizedMyselfFallback();
     mockBulkGetUsers();
     setIsAliveResponse(true);
   }
@@ -89,15 +92,27 @@ public class UserManagementMockServer extends ClientAndServer implements Closeab
     }
   }
 
-  /** Stubs {@code GET /internal/users/myself} with the {@code ZM_AUTH_TOKEN} cookie for the given token. */
+  /** Stubs {@code GET /internal/users/myself} matching the {@code ZM_AUTH_TOKEN} header for the given token. */
   public void registerToken(String token, MyselfDto userMyself) {
     HttpRequest request =
         request()
             .withMethod("GET")
             .withPath("/internal/users/myself")
-            .withHeader(Header.header("Cookie", "ZM_AUTH_TOKEN=" + token));
+            .withHeader(Header.header("ZM_AUTH_TOKEN", token));
     clear(request);
     when(request).respond(response().withStatusCode(200).withBody(JsonBody.json(userMyself)));
+  }
+
+  /**
+   * Low-priority fallback for {@code GET /internal/users/myself}: returns 401 whenever the
+   * request's {@code ZM_AUTH_TOKEN} header doesn't match any token registered via
+   * {@link #registerToken(String, MyselfDto)}, mirroring real User Management behaviour for
+   * unknown/invalid tokens.
+   */
+  private void registerUnauthorizedMyselfFallback() {
+    HttpRequest request = request().withMethod("GET").withPath("/internal/users/myself");
+    when(request, Times.unlimited(), TimeToLive.unlimited(), -10)
+        .respond(response().withStatusCode(401));
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@ SPDX-License-Identifier: AGPL-3.0-only
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <maven.version.ignore>(?i).*(.|-)(alpha|beta|m|rc)([-.]?\d+)?</maven.version.ignore>
-        <!-- Carbonio User Management gRPC SDK -->
-        <carbonio-user-management-grpc-sdk.version>1.0.3-dev.21.79fc3fa2</carbonio-user-management-grpc-sdk.version>
+        <!-- Carbonio User Management REST SDK -->
+        <carbonio-user-management-rest-sdk.version>1.2.5-SNAPSHOT.161.d4c8d51b</carbonio-user-management-rest-sdk.version>
         <!-- Storages -->
         <storages-sdk.version>0.0.15-SNAPSHOT</storages-sdk.version>
         <!-- Previewer -->
@@ -67,8 +67,6 @@ SPDX-License-Identifier: AGPL-3.0-only
              the new REST SDK), but io.vavr.control.Option/Try are used directly across this
              codebase, so it must now be declared explicitly. -->
         <io.vavr.version>0.11.0</io.vavr.version>
-        <!-- gRPC -->
-        <io.grpc.version>1.73.0</io.grpc.version>
         <!-- Jetty -->
         <org.eclipse.jetty.version>12.0.19</org.eclipse.jetty.version>
         <org.eclipse.jetty.servlet.version>12.0.19</org.eclipse.jetty.servlet.version>
@@ -150,11 +148,11 @@ SPDX-License-Identifier: AGPL-3.0-only
                 <version>${project.version}</version>
             </dependency>
 
-            <!-- Carbonio User Management gRPC SDK -->
+            <!-- Carbonio User Management REST SDK -->
             <dependency>
                 <groupId>com.zextras.carbonio.user-management</groupId>
-                <artifactId>carbonio-user-management-grpc-sdk</artifactId>
-                <version>${carbonio-user-management-grpc-sdk.version}</version>
+                <artifactId>carbonio-user-management-rest-sdk</artifactId>
+                <version>${carbonio-user-management-rest-sdk.version}</version>
             </dependency>
 
             <!-- Storages sdk -->
@@ -162,19 +160,6 @@ SPDX-License-Identifier: AGPL-3.0-only
                 <groupId>com.zextras</groupId>
                 <artifactId>storages-ce-sdk</artifactId>
                 <version>${storages-sdk.version}</version>
-            </dependency>
-
-            <!-- gRPC dependencies -->
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-netty-shaded</artifactId>
-                <version>${io.grpc.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-inprocess</artifactId>
-                <version>${io.grpc.version}</version>
             </dependency>
 
             <!-- Previewer sdk -->

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <ebean-maven-plugin.version>15.6.0</ebean-maven-plugin.version>
         <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
+        <sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -572,6 +573,14 @@ SPDX-License-Identifier: AGPL-3.0-only
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+            <!-- Maven Central dropped the "sonar" prefix from the org.codehaus.mojo group
+                 metadata, so mvn sonar:sonar can no longer resolve the plugin prefix on its
+                 own. Declaring it here makes the prefix resolvable from the project. -->
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${sonar-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <maven.compiler.target>21</maven.compiler.target>
         <maven.version.ignore>(?i).*(.|-)(alpha|beta|m|rc)([-.]?\d+)?</maven.version.ignore>
         <!-- Carbonio User Management REST SDK -->
-        <carbonio-user-management-rest-sdk.version>1.2.5-SNAPSHOT.161.d4c8d51b</carbonio-user-management-rest-sdk.version>
+        <carbonio-user-management-rest-sdk.version>1.2.5-SNAPSHOT.163.1b809e66</carbonio-user-management-rest-sdk.version>
         <!-- Storages -->
         <storages-sdk.version>0.0.15-SNAPSHOT</storages-sdk.version>
         <!-- Previewer -->

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <maven.compiler.target>21</maven.compiler.target>
         <maven.version.ignore>(?i).*(.|-)(alpha|beta|m|rc)([-.]?\d+)?</maven.version.ignore>
         <!-- Carbonio User Management REST SDK -->
-        <carbonio-user-management-rest-sdk.version>1.2.5-SNAPSHOT.163.1b809e66</carbonio-user-management-rest-sdk.version>
+        <carbonio-user-management-rest-sdk.version>1.2.5-SNAPSHOT.168.774babb1</carbonio-user-management-rest-sdk.version>
         <!-- Storages -->
         <storages-sdk.version>0.0.15-SNAPSHOT</storages-sdk.version>
         <!-- Previewer -->

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <maven.compiler.target>21</maven.compiler.target>
         <maven.version.ignore>(?i).*(.|-)(alpha|beta|m|rc)([-.]?\d+)?</maven.version.ignore>
         <!-- Carbonio User Management REST SDK -->
-        <carbonio-user-management-rest-sdk.version>1.2.5-SNAPSHOT.168.774babb1</carbonio-user-management-rest-sdk.version>
+        <carbonio-user-management-rest-sdk.version>1.3.0-1</carbonio-user-management-rest-sdk.version>
         <!-- Storages -->
         <storages-sdk.version>0.0.15-SNAPSHOT</storages-sdk.version>
         <!-- Previewer -->


### PR DESCRIPTION
Migrates this service off the user-management **gRPC** SDK onto the new generated **REST** SDK, plus the fixes found while reviewing the migration.

**SDK:** `com.zextras.carbonio.user-management:carbonio-user-management-rest-sdk:1.3.0-1` (released — zextras/carbonio-user-management#185, tag `v1.3.0`)

> ℹ️ The `myself` token now travels as the **`ZM_AUTH_TOKEN` header**, not a cookie — openapi-generator's `native` library silently drops cookie params. The browser→service hop still uses `Cookie:` and is unchanged.

### What changed
- gRPC client → generated REST SDK
- **`isAlive()` caught the wrong exception.** The `HttpClient` wrapper rethrows a `RuntimeException`, so `catch (IOException)` never fired and an unreachable dependency turned `GET /health` into a **500** — which also marked the Docker container unhealthy because of someone else's outage. Now `catch (Exception)`.
- `/health` memoized per invocation (it was making up to ~6 real network round trips per poll)
- `getCode()==0`/5xx → `AuthenticationException` (dependency failure) instead of a silent 401
- Raw auth token redacted from warning logs
- Explicit 5s connect / 5s read timeouts
- `sonar-maven-plugin` declared

> The health probe targets `/q/health/live`, which the Consul L7 intention denied until UM's companion change. Without both, `/health` would have been permanently ERROR on every installation.

### Verified on the prymta demo
Deployed and exercised end-to-end with a real account: header contract (cookie on the internal hop correctly returns 401), trusted forwards, and this service's own authenticated API.

### Expected on the first CI run
`Generated Files Sync` regenerates the stale `THIRDPARTIES` on `PR-*` branches, marks the build **UNSTABLE** and stops the pipeline. That is the normal flow — let the bot commit, then re-trigger.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTvZcnJY8BnvsnDPcTLsQA

