### PR TITLE
ci: run 'mvn package' (skip tests) in pre-commit maven hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
     rev: v0.3.4
     hooks:
       - id: maven
-        args: [ 'compile' ]
+        args: [ 'package', '--', '-DskipTests' ]
 
   - repo: local
     hooks:


### PR DESCRIPTION
Change the pre-commit `maven` hook from `compile` to `package`.

**Why:** the generated docs (OpenAPI `openapi.json/yaml`, `configs.md`, THIRDPARTIES) are produced at the Maven **package** phase, not at `compile`. The previous hook (`mvn compile`) never regenerated them, so stale generated docs could slip through pre-commit. Running `package` regenerates them and keeps them in sync.

**Tests:** skipped — `-DskipTests` (test execution). Verified locally: `mvn package -DskipTests` builds and runs 0 unit/integration tests. (`mvn package` never reaches the `integration-test`/`verify` phases, so failsafe/IT don't run regardless.)

Hook now:
```yaml
  - id: maven
    args: [ 'package', '--', '-DskipTests' ]
```
The `--` is required by the `ejba/pre-commit-maven` argparse wrapper so the `-D` flag is passed through to Maven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
